### PR TITLE
Update separator used in dependabot update branches so they are valid…

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # to ensure they are valid docker tag names (used in build pipeline)
+      separator: "-"


### PR DESCRIPTION
… docker tag names

if we want to keep auto dependabot updates on, we should make this change so they pass CI checks!
