### PR TITLE
Add branded page title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon_32.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Care directory" />
+    <meta name="description" content="OwnPath by Colorado Behavioral Health Administration" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon_180.ico" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Care Directory</title>
+    <title>OwnPath by Colorado Behavioral Health Administration</title>
 
     <!-- Google Analytics -->
     <script

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
   const { t } = useTranslation();
 
   useEffect(() => {
-    document.title = t(`common.title`);
+    document.title = t("common.title");
   });
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-
+import React, { useEffect } from "react";
 import { Route, Routes } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 import Layout from "./components/Layout";
 import Search from "./pages/Search/Search";
@@ -10,6 +10,12 @@ import Whoops from "./pages/Whoops";
 import GuidedSearch from "./pages/GuidedSearch";
 
 function App() {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    document.title = t(`common.title`);
+  });
+
   return (
     <div className="App">
       <Routes>

--- a/src/translations/en/common.json
+++ b/src/translations/en/common.json
@@ -45,5 +45,6 @@
     "Mongolian": "Mongolian / Монгол",
     "Cantonese": "Cantonese / 粵語"
   },
-  "closed": "Closed"
+  "closed": "Closed",
+  "title": "OwnPath by Colorado Behavioral Health Administration"
 }

--- a/src/translations/en/common.json
+++ b/src/translations/en/common.json
@@ -46,5 +46,5 @@
     "Cantonese": "Cantonese / 粵語"
   },
   "closed": "Closed",
-  "title": "OwnPath by Colorado Behavioral Health Administration"
+  "title": "OwnPath"
 }

--- a/src/translations/es/common.json
+++ b/src/translations/es/common.json
@@ -46,5 +46,5 @@
     "Cantonese": "Chino cantonés / 粵語"
   },
   "closed": "Cerrada",
-  "title": "Mi Propia Senda por Colorado Behavioral Health Administration"
+  "title": "Mi Propia Senda"
 }

--- a/src/translations/es/common.json
+++ b/src/translations/es/common.json
@@ -45,5 +45,6 @@
     "Mongolian": "Mongol / Монгол",
     "Cantonese": "Chino cantonés / 粵語"
   },
-  "closed": "Cerrada"
+  "closed": "Cerrada",
+  "title": "Mi Propia Senda por Colorado Behavioral Health Administration"
 }


### PR DESCRIPTION
Noticed that the page title still said "Care Directory", so just added in something more in line with the brand. Does this work?

**Before:**
![image](https://user-images.githubusercontent.com/950486/180869714-46df061a-75e9-47fc-b799-97dd4d42a256.png)

**After (EN):**
"OwnPath by Colorado Behavioral Health Administration"

![image](https://user-images.githubusercontent.com/950486/180869824-00525cda-9324-479e-932a-9548c6dba499.png)

**After (ES):**

"Mi Propia Senda por Colorado Behavioral Health Administration"

![image](https://user-images.githubusercontent.com/950486/180869911-ca9bf0c3-8650-4012-9286-75a238248519.png)


**Question**: Wondering if there's a way to do this in `src/public/index.html` dynamically. Curious how this might show up for Spanish web searchers.