### PR TITLE
exclude dev & staging traffic in google analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,8 +36,9 @@
         dataLayer.push(arguments);
       }
       gtag("js", new Date());
-
-      gtag("config", "G-41V1YRXFBC", { anonymize_ip: true });
+      const PROD_HOSTS = ["ownpath.co", "mipropiasenda.co", "ownpathcolorado.com", "mipropiasendacolorado.com"];
+      const isProd = PROD_HOSTS.includes(window.location.host)
+      gtag("config", "G-41V1YRXFBC", { anonymize_ip: true, debug_mode: !isProd });
     </script>
   </head>
   <body>


### PR DESCRIPTION
tested on dev and confirmed that dev traffic shows up in the debug pane in the GA account. and then configured a filter in the GA ui to exclude dev traffic (weirdly i cannot find a way to filter traffic by domain directly in the GA ui, and it seems like you can only filter out events marked as internal traffic or dev traffic 🤷)

one note: we'll need to tweak this a lil if we switch to using google tag manager - i think in that case we'd go down the route of using [react-gtm](https://www.npmjs.com/package/react-gtm-module), getting rid of this script in index.html, and initializing via react-gtm