### PR TITLE
debug mode fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,8 @@
       gtag("js", new Date());
       const PROD_HOSTS = ["ownpath.co", "mipropiasenda.co", "ownpathcolorado.com", "mipropiasendacolorado.com"];
       const isProd = PROD_HOSTS.includes(window.location.host)
-      gtag("config", "G-9L5WD4V6NV", { anonymize_ip: true, debug_mode: !isProd });
+      const debugConfig = isProd ? {} : { debug_mode: true}
+      gtag("config", "G-9L5WD4V6NV", { anonymize_ip: true, ...debugConfig });
     </script>
   </head>
   <body>


### PR DESCRIPTION
possibly a google analytics bug - it seems that when debug_mode is set but set to false, the filters in google analytics don't work properly and don't respect the value of the flag. updating config accordingly to leave out `debug_mode` if it should be false...