### PR TITLE
mobile styling polish

### DIFF
--- a/e2e/guided-search.spec.ts
+++ b/e2e/guided-search.spec.ts
@@ -9,7 +9,9 @@ test('Homepage has "Try our guided experience" button that leads to the guided-s
   page,
 }) => {
   await expect(page).toHaveTitle(/OwnPath/);
-  const guidedExperience = page.locator("text=Try our guided experience");
+  const guidedExperience = page.locator("a:visible", {
+    hasText: "Try our guided experience",
+  });
   await expect(guidedExperience).toHaveAttribute("href", "/guided-search");
   await guidedExperience.click();
   expect(page.url()).toContain("/guided-search");

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -26,7 +26,7 @@ function Banner() {
   return (
     <div className="Banner usa-dark-background font-body-3xs">
       <Grid row className="flex-justify-end">
-        <Grid col="auto" className="padding-x-4">
+        <Grid col="auto" className="padding-x-2">
           <Grid row className="flex-justify-end flex-align-center">
             <Globe height={15} fill="white" />
             <Label

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,11 +16,11 @@ function Footer() {
       primary={
         <div className="padding-x-4 display-flex flex-row">
           <Grid row className="flex-align-center padding-y-2">
-            <Grid col="auto">
-              <BhaLogo height="40" />
+            <Grid col="auto" className="display-none tablet:display-block">
+              <BhaLogo height="40" className="margin-right-2" />
             </Grid>
 
-            <Grid col className="margin-left-2">
+            <Grid col>
               <h2 className="margin-y-1">{t("privacyCommitmentHeading")}</h2>
               <p className="margin-y-1">{t("privacyCommitment")}</p>
             </Grid>

--- a/src/components/Home/GuidedSearchCard.tsx
+++ b/src/components/Home/GuidedSearchCard.tsx
@@ -3,27 +3,33 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ReactComponent as Hands } from "../../images/hands.svg";
 
-function GuidedSearchCard() {
+function GuidedSearchCard({ isMobile }: { isMobile: boolean }) {
   const { t } = useTranslation();
-  return (
-    <Card
-      gridLayout={{ col: 12, tablet: { col: 7 } }}
-      containerProps={{ className: "border-0" }}
-    >
-      <div className="usa-card__header-alt display-flex flex-justify-center margin-top-1">
-        <Hands className="data-icon margin-right-1" />
-        <div>
-          <h2 className="margin-top-0">{t("guidedSearchHeading")}</h2>
-          <p>{t("guidedSearchPrompt")}</p>
-          <Link
-            to="/guided-search"
-            className="usa-button margin-0 margin-top-05"
-          >
-            {t("guidedSearchButton")}
-          </Link>
-        </div>
+  return isMobile ? (
+    <div className="display-flex flex-column">
+      <Hands className="data-icon margin-right-1" />
+      <div className="margin-top-2">
+        <h2 className="margin-top-0">{t("guidedSearchHeading")}</h2>
+        <p>{t("guidedSearchPrompt")}</p>
+        <Link
+          to="/guided-search"
+          className="usa-button width-full margin-0 margin-top-1"
+        >
+          {t("guidedSearchButton")}
+        </Link>
       </div>
-    </Card>
+    </div>
+  ) : (
+    <div className="display-flex flex-justify-center">
+      <Hands className="data-icon margin-right-1" />
+      <div>
+        <h2 className="margin-top-0">{t("guidedSearchHeading")}</h2>
+        <p>{t("guidedSearchPrompt")}</p>
+        <Link to="/guided-search" className="usa-button margin-0 margin-top-1">
+          {t("guidedSearchButton")}
+        </Link>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/Home/ZipCard.tsx
+++ b/src/components/Home/ZipCard.tsx
@@ -24,43 +24,35 @@ function ZipCard() {
   const [showValidation, setShowValidation] = useState<boolean>(false);
 
   return (
-    <Card
-      className="margin-bottom-0"
-      containerProps={{
-        className: "border-0 margin-bottom-0",
-      }}
-      gridLayout={{ col: 12, tablet: { col: 4 } }}
-    >
-      <CardBody>
-        <h2>{t("zipCodePrompt")}</h2>
-        <form
-          onSubmit={(evt) => {
-            evt.preventDefault();
-            if (zipMeta.isValidZip) {
-              navigate({
-                pathname: "/search",
-                search: createSearchParams({
-                  ...filters,
-                  miles: `${zipMeta.defaultRadiusMiles}`,
-                }).toString(),
-              });
-            } else {
-              setShowValidation(true);
-            }
-          }}
+    <div>
+      <h2 className="margin-top-0">{t("zipCodePrompt")}</h2>
+      <form
+        onSubmit={(evt) => {
+          evt.preventDefault();
+          if (zipMeta.isValidZip) {
+            navigate({
+              pathname: "/search",
+              search: createSearchParams({
+                ...filters,
+                miles: `${zipMeta.defaultRadiusMiles}`,
+              }).toString(),
+            });
+          } else {
+            setShowValidation(true);
+          }
+        }}
+      >
+        <ZipInput
+          zip={filters.zip}
+          setZip={(zip) => setFilters({ ...filters, zip })}
+          showError={showValidation}
         >
-          <ZipInput
-            zip={filters.zip}
-            setZip={(zip) => setFilters({ ...filters, zip })}
-            showError={showValidation}
-          >
-            <ZipButton type="submit" className="usa-button margin-left-1">
-              {t("search")}
-            </ZipButton>
-          </ZipInput>
-        </form>
-      </CardBody>
-    </Card>
+          <ZipButton type="submit" className="usa-button margin-left-1">
+            {t("search")}
+          </ZipButton>
+        </ZipInput>
+      </form>
+    </div>
   );
 }
 

--- a/src/components/Home/ZipCard.tsx
+++ b/src/components/Home/ZipCard.tsx
@@ -13,7 +13,7 @@ const ZipButton = styled(Button)`
   margin-right: 0;
 `;
 
-function ZipCard() {
+function ZipCard({ id }: { id?: string }) {
   const [filters, setFilters] = useState<SearchFilters>(EMPTY_SEARCH_FILTERS);
 
   const { t } = useTranslation();
@@ -46,6 +46,7 @@ function ZipCard() {
           zip={filters.zip}
           setZip={(zip) => setFilters({ ...filters, zip })}
           showError={showValidation}
+          id={id}
         >
           <ZipButton type="submit" className="usa-button margin-left-1">
             {t("search")}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -50,18 +50,17 @@ function Layout() {
         <div className="margin-x-2 margin-top-2">
           <HighlightBox size="sm">
             <div className="display-flex flex-justify">
-              <div className="display-none tablet:display-block">
-                <Phone className="data-icon margin-right-2" />
-              </div>
-              <div>
-                <>
+              <div className="display-flex">
+                <div className="display-none tablet:display-block">
+                  <Phone className="data-icon margin-right-2" />
+                </div>
+                <div>
                   {t("crisisAlert")}{" "}
                   <Link href="tel:+18444938255" className="text-no-wrap">
                     {t("crisisAlertNumber")}
                   </Link>
-                </>
+                </div>
               </div>
-
               <Button
                 className="width-auto margin-left-1"
                 type="button"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,8 +9,8 @@ import { ReactComponent as Close } from "../images/close.svg";
 import { ReactComponent as MiPropiaSendaLogo } from "../images/logos/mi_propia_senda.svg";
 import styled from "styled-components";
 import { useState } from "react";
-import AppAlert from "./AppAlert";
 import { useTranslation } from "react-i18next";
+import HighlightBox from "./HighlightBox";
 
 const Wrapper = styled.div`
   min-height: 100%;
@@ -27,9 +27,17 @@ function Layout() {
         <div className="display-flex flex-justify-center flex-align-center border-bottom border-base-lighter padding-y-2 padding-x-1">
           <a href="/" title="Home" aria-label="Home">
             {i18n.language === "es" ? (
-              <MiPropiaSendaLogo height={38} width="auto" title={t("ownPathLogoAlt")} />
+              <MiPropiaSendaLogo
+                height={38}
+                width="auto"
+                title={t("ownPathLogoAlt")}
+              />
             ) : (
-              <OwnPathLogo height={38} width="auto" title={t("ownPathLogoAlt")} />
+              <OwnPathLogo
+                height={38}
+                width="auto"
+                title={t("ownPathLogoAlt")}
+              />
             )}
           </a>
           <div className="margin-x-1 tablet:margin-x-2">{t("by")}</div>
@@ -40,8 +48,11 @@ function Layout() {
       </Header>
       {showCrisisAlert && location.pathname !== "/guided-search" && (
         <div className="margin-x-2 margin-top-2">
-          <AppAlert Icon={Phone}>
+          <HighlightBox size="sm">
             <div className="display-flex flex-justify">
+              <div className="display-none tablet:display-block">
+                <Phone className="data-icon margin-right-2" />
+              </div>
               <div>
                 <>
                   {t("crisisAlert")}{" "}
@@ -52,7 +63,7 @@ function Layout() {
               </div>
 
               <Button
-                className="width-auto margin-x-1"
+                className="width-auto margin-left-1"
                 type="button"
                 unstyled
                 title="close"
@@ -61,7 +72,7 @@ function Layout() {
                 <Close className="data-icon" />
               </Button>
             </div>
-          </AppAlert>
+          </HighlightBox>
         </div>
       )}
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -28,7 +28,7 @@ function Layout() {
           <a href="/" title="Home" aria-label="Home">
             {i18n.language === "es" ? (
               <MiPropiaSendaLogo
-                height={38}
+                height={34}
                 width="auto"
                 title={t("ownPathLogoAlt")}
               />
@@ -42,7 +42,10 @@ function Layout() {
           </a>
           <div className="margin-x-1 tablet:margin-x-2">{t("by")}</div>
           <a href="https://bha.colorado.gov/" target="_blank" rel="noreferrer">
-            <ColoradoBhaLogo height={34} width="auto" />
+            <ColoradoBhaLogo
+              height={i18n.language === "es" ? 32 : 34}
+              width="auto"
+            />
           </a>
         </div>
       </Header>

--- a/src/components/ZipInput.tsx
+++ b/src/components/ZipInput.tsx
@@ -8,6 +8,7 @@ type ZipInputProps = {
   showError?: boolean;
   noLabel?: boolean;
   autoFocus?: boolean;
+  id?: string;
 };
 
 function ZipInput({
@@ -17,18 +18,20 @@ function ZipInput({
   noLabel = false,
   autoFocus = false,
   showError = false,
+  id,
 }: PropsWithChildren<ZipInputProps>) {
   const { t } = useTranslation();
+  const inputId = id || "zip";
 
   return (
     <div className="width-full">
-      <Label htmlFor="zip" className="margin-bottom-1" srOnly={noLabel}>
+      <Label htmlFor={inputId} className="margin-bottom-1" srOnly={noLabel}>
         {t("locationTitle")}
       </Label>
       <div className="display-flex">
         <TextInput
           className="margin-top-0 tablet:width-15"
-          id="zip"
+          id={inputId}
           name="zip"
           type="text"
           maxLength={5}

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,6 @@ h5 {
 h1 {
   font-size: 2rem;
 }
-
 h2 {
   font-size: 1.3rem;
 }
@@ -47,6 +46,18 @@ p {
   font-weight: 300;
   line-height: 1.625;
   font-size: 1rem;
+}
+
+@media screen and (max-width: 480px) {
+  h1 {
+    font-size: 1.6rem;
+  }
+  h2 {
+    font-size: 1.2rem;
+  }
+  h3 {
+    font-size: 1.1rem;
+  }
 }
 
 /* override USWDS settings */

--- a/src/index.css
+++ b/src/index.css
@@ -50,13 +50,13 @@ p {
 
 @media screen and (max-width: 480px) {
   h1 {
-    font-size: 1.6rem;
+    font-size: 1.602rem;
   }
   h2 {
-    font-size: 1.2rem;
+    font-size: 1.266rem;
   }
   h3 {
-    font-size: 1.1rem;
+    font-size: 1.125rem;
   }
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -78,13 +78,13 @@ function Home() {
               >
                 <h1 className="text-white padding-2">{t("homePageHeading")}</h1>
               </div>
-              <div className="tablet:display-none bg-white radius-lg padding-3">
+              <div className="tablet:display-none bg-white radius-lg padding-x-3 padding-top-3">
                 <h1 className="margin-0">{t("homePageHeading")}</h1>
               </div>
             </Grid>
             <Grid col={12}>
               <div className="display-none tablet:display-block" aria-hidden>
-                <div className="radius-lg bg-white padding-3 display-flex desktop:padding-y-4 tablet:margin-x-2 desktop:margin-x-0">
+                <div className="radius-lg bg-white padding-4 display-flex desktop:padding-y-4 tablet:margin-x-2 desktop:margin-x-0">
                   <ZipCard id="desktop_zip" />
                   <VerticalLineText>{t("or")}</VerticalLineText>
                   <GuidedSearchCard isMobile={false} />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,55 +13,13 @@ import GuidedSearchCard from "../components/Home/GuidedSearchCard";
 import { logPageView } from "../analytics";
 
 const Hero = styled.img`
-  max-width: 110%;
-  margin-left: -5%;
-  border-radius: 10px;
-  @media only screen and (min-width: 768px) and (max-width: 1279px) {
-    border-radius: 5px;
-    width: 100%;
-    max-width: 110%;
-    margin: 0;
-  }
-  @media (max-width: 767px) {
-    border-radius: 0px;
-    max-width: 100vw;
-    margin-left: -4.5%;
-    width: 100vw;
-    object-fit: cover;
-    object-position: right;
-    height: calc(100vw - 50px);
-  }
+  min-height: 26vh;
+  object-fit: cover;
+  object-position: right;
 `;
 
-const ContentOverlay = styled.div`
-  position: relative;
-  margin-top: -28%;
-  @media (min-width: 40em) {
-    margin-top: -22%;
-  }
-`;
-
-const Heading = styled.h1`
-  color: black;
-  background-color: white;
-  padding: 1rem 1.2rem 0 1.2rem;
-  @media (min-width: 40em) {
-    color: white;
-    background-color: transparent;
-    padding: 0;
-  }
-  @media only screen and (min-width: 768px) and (max-width: 1279px) {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-  @media only screen and (min-width: 768px) and (max-width: 1023px) {
-    width: 70%;
-  }
-  @media (max-width: 414px) {
-    font-size: 1.75rem;
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
+const OverlaySection = styled.div`
+  margin-top: -8vh;
 `;
 
 const Line = styled.div`
@@ -100,29 +58,36 @@ function Home() {
   }, []);
 
   return (
-    <GridContainer>
-      <Hero src={heroPath} alt="hero image" />
-      <ContentOverlay>
-        <Grid row>
-          <Grid col={12} desktop={{ col: 7 }}>
-            <Heading className="radius-lg padding-y-2 text-bold">
-              {t("homePageHeading")}
-            </Heading>
-          </Grid>
-          <Grid col={12}>
-            <CardGroup
-              className="bg-white radius-lg padding-x-1 tablet:padding-top-3 justify-content-around"
-              role="list"
-            >
-              <ZipCard />
-              <div className="display-flex flex-justify-center margin-bottom-2">
-                <Line></Line>
-                <Or>{t("or")}</Or>
+    <>
+      <div className="position-relative padding-x-0 tablet:padding-x-2">
+        <Hero src={heroPath} alt="hero image" />
+      </div>
+      <GridContainer>
+        <OverlaySection>
+          <Grid row>
+            <Grid col={12} desktop={{ col: 7 }} tablet={{ col: 8 }}>
+              <div className="display-none tablet:display-block position-absolute bottom-0 left-0">
+                <h1 className="text-white padding-2">{t("homePageHeading")}</h1>
               </div>
-              <GuidedSearchCard />
-            </CardGroup>
+              <div className="tablet:display-none bg-white radius-lg padding-3">
+                <h1 className="margin-0">{t("homePageHeading")}</h1>
+              </div>
+            </Grid>
+            <Grid col={12}>
+              <CardGroup
+                className="bg-white radius-lg padding-x-1 tablet:padding-top-3 justify-content-around"
+                role="list"
+              >
+                <ZipCard />
+                <div className="display-flex flex-justify-center margin-bottom-2">
+                  <Line></Line>
+                  <Or>{t("or")}</Or>
+                </div>
+                <GuidedSearchCard />
+              </CardGroup>
+            </Grid>
           </Grid>
-        </Grid>
+        </OverlaySection>
         <Grid row className="margin-top-3">
           <Grid col={12}>
             <CardGroup>
@@ -180,8 +145,8 @@ function Home() {
             </CardGroup>
           </Grid>
         </Grid>
-      </ContentOverlay>
-    </GridContainer>
+      </GridContainer>
+    </>
   );
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -85,7 +85,7 @@ function Home() {
             <Grid col={12}>
               <div className="display-none tablet:display-block" aria-hidden>
                 <div className="radius-lg bg-white padding-3 display-flex desktop:padding-y-4 tablet:margin-x-2 desktop:margin-x-0">
-                  <ZipCard />
+                  <ZipCard id="desktop_zip" />
                   <VerticalLineText>{t("or")}</VerticalLineText>
                   <GuidedSearchCard isMobile={false} />
                 </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -72,7 +72,10 @@ function Home() {
         <OverlaySection>
           <Grid row>
             <Grid col={12} desktop={{ col: 7 }} tablet={{ col: 8 }}>
-              <div className="display-none tablet:display-block position-absolute bottom-0 left-0">
+              <div
+                className="display-none tablet:display-block position-absolute bottom-0 left-0"
+                aria-hidden
+              >
                 <h1 className="text-white padding-2">{t("homePageHeading")}</h1>
               </div>
               <div className="tablet:display-none bg-white radius-lg padding-3">
@@ -80,7 +83,7 @@ function Home() {
               </div>
             </Grid>
             <Grid col={12}>
-              <div className="display-none tablet:display-block">
+              <div className="display-none tablet:display-block" aria-hidden>
                 <div className="radius-lg bg-white padding-3 display-flex desktop:padding-y-4 tablet:margin-x-2 desktop:margin-x-0">
                   <ZipCard />
                   <VerticalLineText>{t("or")}</VerticalLineText>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -14,6 +14,8 @@ import { logPageView } from "../analytics";
 
 const Hero = styled.img`
   min-height: 26vh;
+  max-height: 22rem;
+  width: 100%;
   object-fit: cover;
   object-position: right;
 `;
@@ -22,30 +24,34 @@ const OverlaySection = styled.div`
   margin-top: -8vh;
 `;
 
-const Line = styled.div`
-  border-bottom: 1px solid black;
-  width: 100%;
-  margin-bottom: 1.2rem;
-  margin-left: 10%;
-  @media (min-width: 40em) {
-    border-bottom: none;
-    border-left: 1px solid black;
-    width: auto;
-    height: 100%;
-    position: relative;
-    right: -6%;
+const HorizontalLineText = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin: 2rem;
+  &:before,
+  &:after {
+    content: "";
+    flex: 1 1;
+    border-bottom: 1px solid;
+    margin: auto;
+    margin-right: 1rem;
+    margin-left: 1rem;
   }
 `;
 
-const Or = styled.div`
-  background-color: white;
-  height: 2rem;
-  padding: 0 1rem;
-  position: relative;
-  left: -45%;
-  @media (min-width: 40em) {
-    padding: 0.25rem 1rem 0.5rem 1rem;
-    top: 40%;
+const VerticalLineText = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-right: 2rem;
+  margin-left: 2rem;
+  &:before,
+  &:after {
+    content: "";
+    flex: 1 1;
+    border-left: 1px solid;
+    margin: auto;
+    margin-bottom: 1rem;
+    margin-top: 1rem;
   }
 `;
 
@@ -74,17 +80,20 @@ function Home() {
               </div>
             </Grid>
             <Grid col={12}>
-              <CardGroup
-                className="bg-white radius-lg padding-x-1 tablet:padding-top-3 justify-content-around"
-                role="list"
-              >
-                <ZipCard />
-                <div className="display-flex flex-justify-center margin-bottom-2">
-                  <Line></Line>
-                  <Or>{t("or")}</Or>
+              <div className="display-none tablet:display-block">
+                <div className="radius-lg bg-white padding-3 display-flex desktop:padding-y-4 tablet:margin-x-2 desktop:margin-x-0">
+                  <ZipCard />
+                  <VerticalLineText>{t("or")}</VerticalLineText>
+                  <GuidedSearchCard isMobile={false} />
                 </div>
-                <GuidedSearchCard />
-              </CardGroup>
+              </div>
+              <div className="tablet:display-none">
+                <div className="radius-lg bg-white padding-3 display-flex flex-column">
+                  <ZipCard />
+                  <HorizontalLineText>{t("or")}</HorizontalLineText>
+                  <GuidedSearchCard isMobile={true} />
+                </div>
+              </div>
             </Grid>
           </Grid>
         </OverlaySection>


### PR DESCRIPTION
a bunch of misc fixes:
- remove phone icon in top banner on mobile to conserve space
- spacing polish on top banner
- simplify hero image styling + prevent hero image from taking up so much of the screen <768px
- simplify "or" styling + fix broken "or" alignment @ ~700px
- remove empty space on right side of the page on mobile & tablet
- fix floating header box @ ~600px
- guided search mobile polish: icon position + button width

recommend viewing the diff w/ whitespace changes hidden