### PR TITLE
desktop search results scroll fix

### DIFF
--- a/src/components/Search/ResultsList.tsx
+++ b/src/components/Search/ResultsList.tsx
@@ -8,9 +8,9 @@ type ResultsListProps = {
 };
 
 const DESKTOP_CLASSES =
-  "border-bottom border-base-lighter padding-y-3 padding-x-2";
+  "border-bottom border-base-lighter padding-y-3 padding-x-5";
 const DESKTOP_CLASSES_ACTIVE =
-  "border-05 radius-sm border-primary-light padding-y-3 padding-x-2";
+  "border-05 radius-sm border-primary-light padding-y-3 padding-x-5";
 const MOBILE_CLASSES =
   "border border-base-lighter radius-lg padding-2 margin-bottom-1";
 

--- a/src/pages/Search/DesktopResults.tsx
+++ b/src/pages/Search/DesktopResults.tsx
@@ -24,7 +24,7 @@ function DesktopResults({ results }: { results: CareProviderSearchResult[] }) {
   }, [mapRef, results]);
 
   return (
-    <div className="display-none tablet:display-block padding-x-4">
+    <div className="display-none tablet:display-block">
       <Grid row className="border-top border-base-lighter overflow-x-hidden">
         <Grid
           tablet={{ col: 7 }}


### PR DESCRIPTION
## Changes
we have a margin on the side of the search results page on desktop, which makes for two scroll areas, b/c you need to scroll within the map or the result cards to scroll thru results. remove the margin so that the ui is more similar to [medicare.gov results](https://www.medicare.gov/care-compare/results?searchType=Hospital&page=1&city=Broomfield&state=CO&zipcode=80020&radius=25&sort=closest&tealiumEventAction=Landing%20Page%20-%20Search&tealiumSearchLocation=search%20bar)

@admoorgit i upped the left & right padding on the result cards b/c the spacing looked a little off once i removed the margins - lmk if the spacing looks ok

## Screenshots
<img width="1035" alt="Screen Shot 2022-09-07 at 4 30 38 PM" src="https://user-images.githubusercontent.com/1406537/189000648-60a5b134-2efd-4176-8bb3-8dbb62d0e468.png">


## Checklist

- [ ] if adds a new page, adds accessibility tests
- [ ] if adds a new page or new interaction, adds e2e test
- [ ] if adds a new page or new interaction, sends google analytics events and updates [GA doc](https://docs.google.com/document/d/1DfQDUNZPO3B352EhUwXp0el6qrAWz8Jq9cTa1yv8Ty4/edit)
- [ ] if changes filter functionality, updates [filters doc](https://docs.google.com/document/d/1yEdo7IpHCtEKNNF6FMLapBUgcPw_8CY7wGwxKTdtJrU/edit)

Fixes https://app.asana.com/0/1202105544020589/1202701091411266/f
