### PR TITLE
add edge case zip data

### DIFF
--- a/src/data/colorado_zip_data.json
+++ b/src/data/colorado_zip_data.json
@@ -5,8 +5,8 @@
     "POPULATION": 18800,
     "POP_SQMI": 3286.71,
     "SQMI": 5.72,
-    "centroid_lon": -105.1043873,
-    "centroid_lat": 39.7951653
+    "lng": -105.1043873,
+    "lat": 39.7951653
   },
   "80003": {
     "PO_NAME": "Arvada",
@@ -14,8 +14,8 @@
     "POPULATION": 34962,
     "POP_SQMI": 5345.87,
     "SQMI": 6.54,
-    "centroid_lon": -105.0642475,
-    "centroid_lat": 39.82676518
+    "lng": -105.0642475,
+    "lat": 39.82676518
   },
   "80004": {
     "PO_NAME": "Arvada",
@@ -23,8 +23,8 @@
     "POPULATION": 36280,
     "POP_SQMI": 4645.33,
     "SQMI": 7.81,
-    "centroid_lon": -105.1236378,
-    "centroid_lat": 39.81449798
+    "lng": -105.1236378,
+    "lat": 39.81449798
   },
   "80005": {
     "PO_NAME": "Arvada",
@@ -32,8 +32,8 @@
     "POPULATION": 29534,
     "POP_SQMI": 2522.12,
     "SQMI": 11.71,
-    "centroid_lon": -105.127755,
-    "centroid_lat": 39.84790953
+    "lng": -105.127755,
+    "lat": 39.84790953
   },
   "80007": {
     "PO_NAME": "Arvada",
@@ -41,8 +41,8 @@
     "POPULATION": 16899,
     "POP_SQMI": 813.23,
     "SQMI": 20.78,
-    "centroid_lon": -105.1978385,
-    "centroid_lat": 39.857041
+    "lng": -105.1978385,
+    "lat": 39.857041
   },
   "80010": {
     "PO_NAME": "Aurora",
@@ -50,8 +50,8 @@
     "POPULATION": 43863,
     "POP_SQMI": 8183.4,
     "SQMI": 5.36,
-    "centroid_lon": -104.8626703,
-    "centroid_lat": 39.74009707
+    "lng": -104.8626703,
+    "lat": 39.74009707
   },
   "80011": {
     "PO_NAME": "Aurora",
@@ -59,8 +59,8 @@
     "POPULATION": 52198,
     "POP_SQMI": 2198.74,
     "SQMI": 23.74,
-    "centroid_lon": -104.7862874,
-    "centroid_lat": 39.73801508
+    "lng": -104.7862874,
+    "lat": 39.73801508
   },
   "80012": {
     "PO_NAME": "Aurora",
@@ -68,8 +68,8 @@
     "POPULATION": 51243,
     "POP_SQMI": 7097.37,
     "SQMI": 7.22,
-    "centroid_lon": -104.8378605,
-    "centroid_lat": 39.69975154
+    "lng": -104.8378605,
+    "lat": 39.69975154
   },
   "80013": {
     "PO_NAME": "Aurora",
@@ -77,8 +77,8 @@
     "POPULATION": 71382,
     "POP_SQMI": 5076.96,
     "SQMI": 14.06,
-    "centroid_lon": -104.7658488,
-    "centroid_lat": 39.66143007
+    "lng": -104.7658488,
+    "lat": 39.66143007
   },
   "80014": {
     "PO_NAME": "Aurora",
@@ -86,8 +86,8 @@
     "POPULATION": 41640,
     "POP_SQMI": 4769.76,
     "SQMI": 8.73,
-    "centroid_lon": -104.8373798,
-    "centroid_lat": 39.66079283
+    "lng": -104.8373798,
+    "lat": 39.66079283
   },
   "80015": {
     "PO_NAME": "Aurora",
@@ -95,8 +95,8 @@
     "POPULATION": 71009,
     "POP_SQMI": 5617.8,
     "SQMI": 12.64,
-    "centroid_lon": -104.7710395,
-    "centroid_lat": 39.62343496
+    "lng": -104.7710395,
+    "lat": 39.62343496
   },
   "80016": {
     "PO_NAME": "Aurora",
@@ -104,8 +104,8 @@
     "POPULATION": 63182,
     "POP_SQMI": 1368.76,
     "SQMI": 46.16,
-    "centroid_lon": -104.6944725,
-    "centroid_lat": 39.59637136
+    "lng": -104.6944725,
+    "lat": 39.59637136
   },
   "80017": {
     "PO_NAME": "Aurora",
@@ -113,8 +113,8 @@
     "POPULATION": 35475,
     "POP_SQMI": 6757.14,
     "SQMI": 5.25,
-    "centroid_lon": -104.7857876,
-    "centroid_lat": 39.69618776
+    "lng": -104.7857876,
+    "lat": 39.69618776
   },
   "80018": {
     "PO_NAME": "Aurora",
@@ -122,8 +122,8 @@
     "POPULATION": 14370,
     "POP_SQMI": 560.45,
     "SQMI": 25.64,
-    "centroid_lon": -104.6971046,
-    "centroid_lat": 39.69119037
+    "lng": -104.6971046,
+    "lat": 39.69119037
   },
   "80019": {
     "PO_NAME": "Aurora",
@@ -131,8 +131,8 @@
     "POPULATION": 2806,
     "POP_SQMI": 118.2,
     "SQMI": 23.74,
-    "centroid_lon": -104.7008381,
-    "centroid_lat": 39.7820463
+    "lng": -104.7008381,
+    "lat": 39.7820463
   },
   "80020": {
     "PO_NAME": "Broomfield",
@@ -140,8 +140,8 @@
     "POPULATION": 54563,
     "POP_SQMI": 2768.29,
     "SQMI": 19.71,
-    "centroid_lon": -105.0743314,
-    "centroid_lat": 39.93164464
+    "lng": -105.0743314,
+    "lat": 39.93164464
   },
   "80021": {
     "PO_NAME": "Broomfield",
@@ -149,8 +149,8 @@
     "POPULATION": 35884,
     "POP_SQMI": 1498.91,
     "SQMI": 23.94,
-    "centroid_lon": -105.1362283,
-    "centroid_lat": 39.89499936
+    "lng": -105.1362283,
+    "lat": 39.89499936
   },
   "80022": {
     "PO_NAME": "Commerce City",
@@ -158,8 +158,8 @@
     "POPULATION": 55217,
     "POP_SQMI": 565.17,
     "SQMI": 97.7,
-    "centroid_lon": -104.7742012,
-    "centroid_lat": 39.86937246
+    "lng": -104.7742012,
+    "lat": 39.86937246
   },
   "80023": {
     "PO_NAME": "Broomfield",
@@ -167,8 +167,8 @@
     "POPULATION": 28022,
     "POP_SQMI": 1584.95,
     "SQMI": 17.68,
-    "centroid_lon": -105.0119621,
-    "centroid_lat": 39.97432951
+    "lng": -105.0119621,
+    "lat": 39.97432951
   },
   "80026": {
     "PO_NAME": "Lafayette",
@@ -176,8 +176,8 @@
     "POPULATION": 33089,
     "POP_SQMI": 1330.48,
     "SQMI": 24.87,
-    "centroid_lon": -105.1001175,
-    "centroid_lat": 40.01856914
+    "lng": -105.1001175,
+    "lat": 40.01856914
   },
   "80027": {
     "PO_NAME": "Louisville",
@@ -185,8 +185,8 @@
     "POPULATION": 34643,
     "POP_SQMI": 2011.79,
     "SQMI": 17.22,
-    "centroid_lon": -105.1549169,
-    "centroid_lat": 39.95401065
+    "lng": -105.1549169,
+    "lat": 39.95401065
   },
   "80030": {
     "PO_NAME": "Westminster",
@@ -194,8 +194,8 @@
     "POPULATION": 15884,
     "POP_SQMI": 5592.96,
     "SQMI": 2.84,
-    "centroid_lon": -105.0370088,
-    "centroid_lat": 39.82988528
+    "lng": -105.0370088,
+    "lat": 39.82988528
   },
   "80031": {
     "PO_NAME": "Westminster",
@@ -203,8 +203,8 @@
     "POPULATION": 39748,
     "POP_SQMI": 4558.26,
     "SQMI": 8.72,
-    "centroid_lon": -105.0402877,
-    "centroid_lat": 39.87492617
+    "lng": -105.0402877,
+    "lat": 39.87492617
   },
   "80033": {
     "PO_NAME": "Wheat Ridge",
@@ -212,8 +212,8 @@
     "POPULATION": 27518,
     "POP_SQMI": 2981.37,
     "SQMI": 9.23,
-    "centroid_lon": -105.1053536,
-    "centroid_lat": 39.7739166
+    "lng": -105.1053536,
+    "lat": 39.7739166
   },
   "80045": {
     "PO_NAME": "Aurora",
@@ -221,8 +221,8 @@
     "POPULATION": 1270,
     "POP_SQMI": 1380.43,
     "SQMI": 0.92,
-    "centroid_lon": -104.8373859,
-    "centroid_lat": 39.7474016
+    "lng": -104.8373859,
+    "lat": 39.7474016
   },
   "80101": {
     "PO_NAME": "Agate",
@@ -230,8 +230,8 @@
     "POPULATION": 402,
     "POP_SQMI": 0.95,
     "SQMI": 424.87,
-    "centroid_lon": -103.9512918,
-    "centroid_lat": 39.40599522
+    "lng": -103.9512918,
+    "lat": 39.40599522
   },
   "80102": {
     "PO_NAME": "Bennett",
@@ -239,8 +239,8 @@
     "POPULATION": 6518,
     "POP_SQMI": 21.12,
     "SQMI": 308.56,
-    "centroid_lon": -104.4301839,
-    "centroid_lat": 39.71785399
+    "lng": -104.4301839,
+    "lat": 39.71785399
   },
   "80103": {
     "PO_NAME": "Byers",
@@ -248,8 +248,8 @@
     "POPULATION": 2844,
     "POP_SQMI": 8.05,
     "SQMI": 353.1,
-    "centroid_lon": -104.1007378,
-    "centroid_lat": 39.7775758
+    "lng": -104.1007378,
+    "lat": 39.7775758
   },
   "80104": {
     "PO_NAME": "Castle Rock",
@@ -257,8 +257,8 @@
     "POPULATION": 34138,
     "POP_SQMI": 490.77,
     "SQMI": 69.56,
-    "centroid_lon": -104.8218049,
-    "centroid_lat": 39.30600502
+    "lng": -104.8218049,
+    "lat": 39.30600502
   },
   "80105": {
     "PO_NAME": "Deer Trail",
@@ -266,8 +266,8 @@
     "POPULATION": 1257,
     "POP_SQMI": 3.11,
     "SQMI": 404.21,
-    "centroid_lon": -103.9665776,
-    "centroid_lat": 39.62111558
+    "lng": -103.9665776,
+    "lat": 39.62111558
   },
   "80106": {
     "PO_NAME": "Elbert",
@@ -275,8 +275,8 @@
     "POPULATION": 4712,
     "POP_SQMI": 24.5,
     "SQMI": 192.32,
-    "centroid_lon": -104.5129799,
-    "centroid_lat": 39.18434728
+    "lng": -104.5129799,
+    "lat": 39.18434728
   },
   "80107": {
     "PO_NAME": "Elizabeth",
@@ -284,8 +284,8 @@
     "POPULATION": 14352,
     "POP_SQMI": 93.46,
     "SQMI": 153.56,
-    "centroid_lon": -104.5695335,
-    "centroid_lat": 39.40863322
+    "lng": -104.5695335,
+    "lat": 39.40863322
   },
   "80108": {
     "PO_NAME": "Castle Rock",
@@ -293,8 +293,8 @@
     "POPULATION": 32895,
     "POP_SQMI": 957.92,
     "SQMI": 34.34,
-    "centroid_lon": -104.853097,
-    "centroid_lat": 39.4429185
+    "lng": -104.853097,
+    "lat": 39.4429185
   },
   "80109": {
     "PO_NAME": "Castle Rock",
@@ -302,8 +302,8 @@
     "POPULATION": 26701,
     "POP_SQMI": 902.98,
     "SQMI": 29.57,
-    "centroid_lon": -104.9058554,
-    "centroid_lat": 39.36631928
+    "lng": -104.9058554,
+    "lat": 39.36631928
   },
   "80110": {
     "PO_NAME": "Englewood",
@@ -311,8 +311,8 @@
     "POPULATION": 24722,
     "POP_SQMI": 3751.44,
     "SQMI": 6.59,
-    "centroid_lon": -105.0084706,
-    "centroid_lat": 39.64616249
+    "lng": -105.0084706,
+    "lat": 39.64616249
   },
   "80111": {
     "PO_NAME": "Englewood",
@@ -320,8 +320,8 @@
     "POPULATION": 31701,
     "POP_SQMI": 2114.81,
     "SQMI": 14.99,
-    "centroid_lon": -104.8725327,
-    "centroid_lat": 39.61725301
+    "lng": -104.8725327,
+    "lat": 39.61725301
   },
   "80112": {
     "PO_NAME": "Englewood",
@@ -329,8 +329,8 @@
     "POPULATION": 35101,
     "POP_SQMI": 2011.52,
     "SQMI": 17.45,
-    "centroid_lon": -104.8587799,
-    "centroid_lat": 39.57310996
+    "lng": -104.8587799,
+    "lat": 39.57310996
   },
   "80113": {
     "PO_NAME": "Englewood",
@@ -338,8 +338,8 @@
     "POPULATION": 22489,
     "POP_SQMI": 2909.31,
     "SQMI": 7.73,
-    "centroid_lon": -104.9612012,
-    "centroid_lat": 39.64206315
+    "lng": -104.9612012,
+    "lat": 39.64206315
   },
   "80116": {
     "PO_NAME": "Franktown",
@@ -347,8 +347,8 @@
     "POPULATION": 4561,
     "POP_SQMI": 50.63,
     "SQMI": 90.09,
-    "centroid_lon": -104.719886,
-    "centroid_lat": 39.30755891
+    "lng": -104.719886,
+    "lat": 39.30755891
   },
   "80117": {
     "PO_NAME": "Kiowa",
@@ -356,8 +356,8 @@
     "POPULATION": 2749,
     "POP_SQMI": 17.87,
     "SQMI": 153.87,
-    "centroid_lon": -104.4254609,
-    "centroid_lat": 39.36838621
+    "lng": -104.4254609,
+    "lat": 39.36838621
   },
   "80118": {
     "PO_NAME": "Larkspur",
@@ -365,8 +365,8 @@
     "POPULATION": 6074,
     "POP_SQMI": 39.43,
     "SQMI": 154.03,
-    "centroid_lon": -104.9007973,
-    "centroid_lat": 39.19725036
+    "lng": -104.9007973,
+    "lat": 39.19725036
   },
   "80120": {
     "PO_NAME": "Littleton",
@@ -374,8 +374,8 @@
     "POPULATION": 30765,
     "POP_SQMI": 3511.99,
     "SQMI": 8.76,
-    "centroid_lon": -105.0093016,
-    "centroid_lat": 39.59304031
+    "lng": -105.0093016,
+    "lat": 39.59304031
   },
   "80121": {
     "PO_NAME": "Littleton",
@@ -383,8 +383,8 @@
     "POPULATION": 18434,
     "POP_SQMI": 2539.12,
     "SQMI": 7.26,
-    "centroid_lon": -104.9535904,
-    "centroid_lat": 39.61048211
+    "lng": -104.9535904,
+    "lat": 39.61048211
   },
   "80122": {
     "PO_NAME": "Littleton",
@@ -392,8 +392,8 @@
     "POPULATION": 31628,
     "POP_SQMI": 4511.84,
     "SQMI": 7.01,
-    "centroid_lon": -104.9557094,
-    "centroid_lat": 39.58058881
+    "lng": -104.9557094,
+    "lat": 39.58058881
   },
   "80123": {
     "PO_NAME": "Littleton",
@@ -401,8 +401,8 @@
     "POPULATION": 48401,
     "POP_SQMI": 3641.91,
     "SQMI": 13.29,
-    "centroid_lon": -105.0682838,
-    "centroid_lat": 39.61531055
+    "lng": -105.0682838,
+    "lat": 39.61531055
   },
   "80124": {
     "PO_NAME": "Lone Tree",
@@ -410,8 +410,8 @@
     "POPULATION": 24788,
     "POP_SQMI": 1344.98,
     "SQMI": 18.43,
-    "centroid_lon": -104.9190239,
-    "centroid_lat": 39.51204134
+    "lng": -104.9190239,
+    "lat": 39.51204134
   },
   "80125": {
     "PO_NAME": "Littleton",
@@ -419,8 +419,8 @@
     "POPULATION": 12897,
     "POP_SQMI": 253.68,
     "SQMI": 50.84,
-    "centroid_lon": -105.0568796,
-    "centroid_lat": 39.47982125
+    "lng": -105.0568796,
+    "lat": 39.47982125
   },
   "80126": {
     "PO_NAME": "Littleton",
@@ -428,8 +428,8 @@
     "POPULATION": 46660,
     "POP_SQMI": 4241.82,
     "SQMI": 11,
-    "centroid_lon": -104.9620264,
-    "centroid_lat": 39.54046803
+    "lng": -104.9620264,
+    "lat": 39.54046803
   },
   "80127": {
     "PO_NAME": "Littleton",
@@ -437,8 +437,8 @@
     "POPULATION": 46774,
     "POP_SQMI": 679.16,
     "SQMI": 68.87,
-    "centroid_lon": -105.1576458,
-    "centroid_lat": 39.52940417
+    "lng": -105.1576458,
+    "lat": 39.52940417
   },
   "80128": {
     "PO_NAME": "Littleton",
@@ -446,8 +446,8 @@
     "POPULATION": 35835,
     "POP_SQMI": 3287.61,
     "SQMI": 10.9,
-    "centroid_lon": -105.0759122,
-    "centroid_lat": 39.57369055
+    "lng": -105.0759122,
+    "lat": 39.57369055
   },
   "80129": {
     "PO_NAME": "Littleton",
@@ -455,8 +455,8 @@
     "POPULATION": 30770,
     "POP_SQMI": 4220.85,
     "SQMI": 7.29,
-    "centroid_lon": -105.0122802,
-    "centroid_lat": 39.54476056
+    "lng": -105.0122802,
+    "lat": 39.54476056
   },
   "80130": {
     "PO_NAME": "Littleton",
@@ -464,8 +464,8 @@
     "POPULATION": 28174,
     "POP_SQMI": 5691.72,
     "SQMI": 4.95,
-    "centroid_lon": -104.9216339,
-    "centroid_lat": 39.5397684
+    "lng": -104.9216339,
+    "lat": 39.5397684
   },
   "80131": {
     "PO_NAME": "Louviers",
@@ -473,8 +473,8 @@
     "POPULATION": 279,
     "POP_SQMI": 270.87,
     "SQMI": 1.03,
-    "centroid_lon": -105.0050156,
-    "centroid_lat": 39.47731088
+    "lng": -105.0050156,
+    "lat": 39.47731088
   },
   "80132": {
     "PO_NAME": "Monument",
@@ -482,8 +482,8 @@
     "POPULATION": 25265,
     "POP_SQMI": 740.91,
     "SQMI": 34.1,
-    "centroid_lon": -104.8454405,
-    "centroid_lat": 39.09505624
+    "lng": -104.8454405,
+    "lat": 39.09505624
   },
   "80133": {
     "PO_NAME": "Palmer Lake",
@@ -491,8 +491,8 @@
     "POPULATION": 2861,
     "POP_SQMI": 1104.63,
     "SQMI": 2.59,
-    "centroid_lon": -104.9039686,
-    "centroid_lat": 39.11456276
+    "lng": -104.9039686,
+    "lat": 39.11456276
   },
   "80134": {
     "PO_NAME": "Parker",
@@ -500,8 +500,8 @@
     "POPULATION": 73734,
     "POP_SQMI": 1249.52,
     "SQMI": 59.01,
-    "centroid_lon": -104.7797408,
-    "centroid_lat": 39.48258832
+    "lng": -104.7797408,
+    "lat": 39.48258832
   },
   "80135": {
     "PO_NAME": "Sedalia",
@@ -509,8 +509,8 @@
     "POPULATION": 4427,
     "POP_SQMI": 11.85,
     "SQMI": 373.49,
-    "centroid_lon": -105.1601772,
-    "centroid_lat": 39.26367849
+    "lng": -105.1601772,
+    "lat": 39.26367849
   },
   "80136": {
     "PO_NAME": "Strasburg",
@@ -518,8 +518,8 @@
     "POPULATION": 5895,
     "POP_SQMI": 25.14,
     "SQMI": 234.49,
-    "centroid_lon": -104.2898603,
-    "centroid_lat": 39.80672317
+    "lng": -104.2898603,
+    "lat": 39.80672317
   },
   "80137": {
     "PO_NAME": "Watkins",
@@ -527,8 +527,8 @@
     "POPULATION": 1732,
     "POP_SQMI": 14.82,
     "SQMI": 116.87,
-    "centroid_lon": -104.5938581,
-    "centroid_lat": 39.72931759
+    "lng": -104.5938581,
+    "lat": 39.72931759
   },
   "80138": {
     "PO_NAME": "Parker",
@@ -536,8 +536,8 @@
     "POPULATION": 35758,
     "POP_SQMI": 543.35,
     "SQMI": 65.81,
-    "centroid_lon": -104.6653919,
-    "centroid_lat": 39.51589266
+    "lng": -104.6653919,
+    "lat": 39.51589266
   },
   "80202": {
     "PO_NAME": "Denver",
@@ -545,8 +545,8 @@
     "POPULATION": 19222,
     "POP_SQMI": 17474.55,
     "SQMI": 1.1,
-    "centroid_lon": -104.9975142,
-    "centroid_lat": 39.75244993
+    "lng": -104.9975142,
+    "lat": 39.75244993
   },
   "80203": {
     "PO_NAME": "Denver",
@@ -554,8 +554,8 @@
     "POPULATION": 23591,
     "POP_SQMI": 21843.52,
     "SQMI": 1.08,
-    "centroid_lon": -104.9823634,
-    "centroid_lat": 39.7316184
+    "lng": -104.9823634,
+    "lat": 39.7316184
   },
   "80204": {
     "PO_NAME": "Denver",
@@ -563,8 +563,8 @@
     "POPULATION": 40565,
     "POP_SQMI": 7129.17,
     "SQMI": 5.69,
-    "centroid_lon": -105.020144,
-    "centroid_lat": 39.73497056
+    "lng": -105.020144,
+    "lat": 39.73497056
   },
   "80205": {
     "PO_NAME": "Denver",
@@ -572,8 +572,8 @@
     "POPULATION": 36208,
     "POP_SQMI": 7957.8,
     "SQMI": 4.55,
-    "centroid_lon": -104.9632118,
-    "centroid_lat": 39.75858155
+    "lng": -104.9632118,
+    "lat": 39.75858155
   },
   "80206": {
     "PO_NAME": "Denver",
@@ -581,8 +581,8 @@
     "POPULATION": 26356,
     "POP_SQMI": 10542.4,
     "SQMI": 2.5,
-    "centroid_lon": -104.9528347,
-    "centroid_lat": 39.73043008
+    "lng": -104.9528347,
+    "lat": 39.73043008
   },
   "80207": {
     "PO_NAME": "Denver",
@@ -590,8 +590,8 @@
     "POPULATION": 22123,
     "POP_SQMI": 5658.06,
     "SQMI": 3.91,
-    "centroid_lon": -104.9202593,
-    "centroid_lat": 39.76092836
+    "lng": -104.9202593,
+    "lat": 39.76092836
   },
   "80209": {
     "PO_NAME": "Denver",
@@ -599,8 +599,8 @@
     "POPULATION": 25637,
     "POP_SQMI": 7242.09,
     "SQMI": 3.54,
-    "centroid_lon": -104.9645564,
-    "centroid_lat": 39.70648548
+    "lng": -104.9645564,
+    "lat": 39.70648548
   },
   "80210": {
     "PO_NAME": "Denver",
@@ -608,8 +608,8 @@
     "POPULATION": 38059,
     "POP_SQMI": 6208.65,
     "SQMI": 6.13,
-    "centroid_lon": -104.9619369,
-    "centroid_lat": 39.67795667
+    "lng": -104.9619369,
+    "lat": 39.67795667
   },
   "80211": {
     "PO_NAME": "Denver",
@@ -617,8 +617,8 @@
     "POPULATION": 43614,
     "POP_SQMI": 9481.3,
     "SQMI": 4.6,
-    "centroid_lon": -105.0203241,
-    "centroid_lat": 39.7672451
+    "lng": -105.0203241,
+    "lat": 39.7672451
   },
   "80212": {
     "PO_NAME": "Denver",
@@ -626,8 +626,8 @@
     "POPULATION": 19899,
     "POP_SQMI": 5050.51,
     "SQMI": 3.94,
-    "centroid_lon": -105.0489,
-    "centroid_lat": 39.77185287
+    "lng": -105.0489,
+    "lat": 39.77185287
   },
   "80214": {
     "PO_NAME": "Denver",
@@ -635,8 +635,8 @@
     "POPULATION": 27615,
     "POP_SQMI": 6003.26,
     "SQMI": 4.6,
-    "centroid_lon": -105.0711128,
-    "centroid_lat": 39.74212619
+    "lng": -105.0711128,
+    "lat": 39.74212619
   },
   "80215": {
     "PO_NAME": "Denver",
@@ -644,8 +644,8 @@
     "POPULATION": 19484,
     "POP_SQMI": 3418.25,
     "SQMI": 5.7,
-    "centroid_lon": -105.1157106,
-    "centroid_lat": 39.74372835
+    "lng": -105.1157106,
+    "lat": 39.74372835
   },
   "80216": {
     "PO_NAME": "Denver",
@@ -653,8 +653,8 @@
     "POPULATION": 16652,
     "POP_SQMI": 1595.02,
     "SQMI": 10.44,
-    "centroid_lon": -104.9594267,
-    "centroid_lat": 39.78637962
+    "lng": -104.9594267,
+    "lat": 39.78637962
   },
   "80218": {
     "PO_NAME": "Denver",
@@ -662,8 +662,8 @@
     "POPULATION": 19493,
     "POP_SQMI": 14125.36,
     "SQMI": 1.38,
-    "centroid_lon": -104.9712842,
-    "centroid_lat": 39.73243025
+    "lng": -104.9712842,
+    "lat": 39.73243025
   },
   "80219": {
     "PO_NAME": "Denver",
@@ -671,8 +671,8 @@
     "POPULATION": 68621,
     "POP_SQMI": 9161.68,
     "SQMI": 7.49,
-    "centroid_lon": -105.0347942,
-    "centroid_lat": 39.69503563
+    "lng": -105.0347942,
+    "lat": 39.69503563
   },
   "80220": {
     "PO_NAME": "Denver",
@@ -680,8 +680,8 @@
     "POPULATION": 38700,
     "POP_SQMI": 7485.49,
     "SQMI": 5.17,
-    "centroid_lon": -104.9168548,
-    "centroid_lat": 39.73371116
+    "lng": -104.9168548,
+    "lat": 39.73371116
   },
   "80221": {
     "PO_NAME": "Denver",
@@ -689,8 +689,8 @@
     "POPULATION": 44189,
     "POP_SQMI": 4641.7,
     "SQMI": 9.52,
-    "centroid_lon": -105.0103545,
-    "centroid_lat": 39.81548073
+    "lng": -105.0103545,
+    "lat": 39.81548073
   },
   "80222": {
     "PO_NAME": "Denver",
@@ -698,8 +698,8 @@
     "POPULATION": 22867,
     "POP_SQMI": 6197.02,
     "SQMI": 3.69,
-    "centroid_lon": -104.9278267,
-    "centroid_lat": 39.67143188
+    "lng": -104.9278267,
+    "lat": 39.67143188
   },
   "80223": {
     "PO_NAME": "Denver",
@@ -707,8 +707,8 @@
     "POPULATION": 22186,
     "POP_SQMI": 3968.87,
     "SQMI": 5.59,
-    "centroid_lon": -105.0016573,
-    "centroid_lat": 39.69660255
+    "lng": -105.0016573,
+    "lat": 39.69660255
   },
   "80224": {
     "PO_NAME": "Denver",
@@ -716,8 +716,8 @@
     "POPULATION": 18661,
     "POP_SQMI": 5724.23,
     "SQMI": 3.26,
-    "centroid_lon": -104.9116163,
-    "centroid_lat": 39.68886894
+    "lng": -104.9116163,
+    "lat": 39.68886894
   },
   "80225": {
     "PO_NAME": "Denver",
@@ -725,8 +725,8 @@
     "POPULATION": 0,
     "POP_SQMI": 0,
     "SQMI": 0.93,
-    "centroid_lon": -105.1188331,
-    "centroid_lat": 39.71823905
+    "lng": -105.1188331,
+    "lat": 39.71823905
   },
   "80226": {
     "PO_NAME": "Denver",
@@ -734,8 +734,8 @@
     "POPULATION": 32559,
     "POP_SQMI": 4739.3,
     "SQMI": 6.87,
-    "centroid_lon": -105.086982,
-    "centroid_lat": 39.71000206
+    "lng": -105.086982,
+    "lat": 39.71000206
   },
   "80227": {
     "PO_NAME": "Denver",
@@ -743,8 +743,8 @@
     "POPULATION": 36590,
     "POP_SQMI": 3148.88,
     "SQMI": 11.62,
-    "centroid_lon": -105.1076947,
-    "centroid_lat": 39.66299256
+    "lng": -105.1076947,
+    "lat": 39.66299256
   },
   "80228": {
     "PO_NAME": "Denver",
@@ -752,8 +752,8 @@
     "POPULATION": 35289,
     "POP_SQMI": 3546.63,
     "SQMI": 9.95,
-    "centroid_lon": -105.152079,
-    "centroid_lat": 39.6922663
+    "lng": -105.152079,
+    "lat": 39.6922663
   },
   "80229": {
     "PO_NAME": "Denver",
@@ -761,8 +761,8 @@
     "POPULATION": 56930,
     "POP_SQMI": 4365.8,
     "SQMI": 13.04,
-    "centroid_lon": -104.9591519,
-    "centroid_lat": 39.8550441
+    "lng": -104.9591519,
+    "lat": 39.8550441
   },
   "80230": {
     "PO_NAME": "Denver",
@@ -770,8 +770,8 @@
     "POPULATION": 9296,
     "POP_SQMI": 3380.36,
     "SQMI": 2.75,
-    "centroid_lon": -104.8893991,
-    "centroid_lat": 39.72041171
+    "lng": -104.8893991,
+    "lat": 39.72041171
   },
   "80231": {
     "PO_NAME": "Denver",
@@ -779,8 +779,8 @@
     "POPULATION": 36317,
     "POP_SQMI": 7981.76,
     "SQMI": 4.55,
-    "centroid_lon": -104.8876294,
-    "centroid_lat": 39.67041227
+    "lng": -104.8876294,
+    "lat": 39.67041227
   },
   "80232": {
     "PO_NAME": "Denver",
@@ -788,8 +788,8 @@
     "POPULATION": 22201,
     "POP_SQMI": 5454.79,
     "SQMI": 4.07,
-    "centroid_lon": -105.0906499,
-    "centroid_lat": 39.68953316
+    "lng": -105.0906499,
+    "lat": 39.68953316
   },
   "80233": {
     "PO_NAME": "Denver",
@@ -797,8 +797,8 @@
     "POPULATION": 44467,
     "POP_SQMI": 4881.12,
     "SQMI": 9.11,
-    "centroid_lon": -104.9461133,
-    "centroid_lat": 39.89970306
+    "lng": -104.9461133,
+    "lat": 39.89970306
   },
   "80234": {
     "PO_NAME": "Denver",
@@ -806,8 +806,8 @@
     "POPULATION": 28560,
     "POP_SQMI": 3933.88,
     "SQMI": 7.26,
-    "centroid_lon": -105.0060915,
-    "centroid_lat": 39.9123848
+    "lng": -105.0060915,
+    "lat": 39.9123848
   },
   "80235": {
     "PO_NAME": "Denver",
@@ -815,8 +815,8 @@
     "POPULATION": 8911,
     "POP_SQMI": 2369.95,
     "SQMI": 3.76,
-    "centroid_lon": -105.0915413,
-    "centroid_lat": 39.64551231
+    "lng": -105.0915413,
+    "lat": 39.64551231
   },
   "80236": {
     "PO_NAME": "Denver",
@@ -824,8 +824,8 @@
     "POPULATION": 16445,
     "POP_SQMI": 4808.48,
     "SQMI": 3.42,
-    "centroid_lon": -105.0395203,
-    "centroid_lat": 39.65152807
+    "lng": -105.0395203,
+    "lat": 39.65152807
   },
   "80237": {
     "PO_NAME": "Denver",
@@ -833,8 +833,8 @@
     "POPULATION": 23465,
     "POP_SQMI": 6224.14,
     "SQMI": 3.77,
-    "centroid_lon": -104.9018783,
-    "centroid_lat": 39.64047703
+    "lng": -104.9018783,
+    "lat": 39.64047703
   },
   "80238": {
     "PO_NAME": "Denver",
@@ -842,8 +842,8 @@
     "POPULATION": 25450,
     "POP_SQMI": 4206.61,
     "SQMI": 6.05,
-    "centroid_lon": -104.8820095,
-    "centroid_lat": 39.77618102
+    "lng": -104.8820095,
+    "lat": 39.77618102
   },
   "80239": {
     "PO_NAME": "Denver",
@@ -851,8 +851,8 @@
     "POPULATION": 48327,
     "POP_SQMI": 5958.94,
     "SQMI": 8.11,
-    "centroid_lon": -104.8303972,
-    "centroid_lat": 39.78416168
+    "lng": -104.8303972,
+    "lat": 39.78416168
   },
   "80241": {
     "PO_NAME": "Thornton",
@@ -860,8 +860,8 @@
     "POPULATION": 34071,
     "POP_SQMI": 4895.26,
     "SQMI": 6.96,
-    "centroid_lon": -104.9548999,
-    "centroid_lat": 39.92845056
+    "lng": -104.9548999,
+    "lat": 39.92845056
   },
   "80246": {
     "PO_NAME": "Denver",
@@ -869,8 +869,8 @@
     "POPULATION": 15181,
     "POP_SQMI": 9429.19,
     "SQMI": 1.61,
-    "centroid_lon": -104.9314137,
-    "centroid_lat": 39.70456884
+    "lng": -104.9314137,
+    "lat": 39.70456884
   },
   "80247": {
     "PO_NAME": "Denver",
@@ -878,8 +878,8 @@
     "POPULATION": 30197,
     "POP_SQMI": 9206.4,
     "SQMI": 3.28,
-    "centroid_lon": -104.8813941,
-    "centroid_lat": 39.69653094
+    "lng": -104.8813941,
+    "lat": 39.69653094
   },
   "80249": {
     "PO_NAME": "Denver",
@@ -887,8 +887,8 @@
     "POPULATION": 35235,
     "POP_SQMI": 1015.71,
     "SQMI": 34.69,
-    "centroid_lon": -104.7090716,
-    "centroid_lat": 39.83712928
+    "lng": -104.7090716,
+    "lat": 39.83712928
   },
   "80260": {
     "PO_NAME": "Denver",
@@ -896,8 +896,8 @@
     "POPULATION": 33088,
     "POP_SQMI": 6965.89,
     "SQMI": 4.75,
-    "centroid_lon": -105.0055532,
-    "centroid_lat": 39.86770779
+    "lng": -105.0055532,
+    "lat": 39.86770779
   },
   "80264": {
     "PO_NAME": "Denver",
@@ -905,8 +905,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0,
-    "centroid_lon": -104.9858006,
-    "centroid_lat": 39.74248649
+    "lng": -104.9858006,
+    "lat": 39.74248649
   },
   "80265": {
     "PO_NAME": "Denver",
@@ -914,8 +914,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.01,
-    "centroid_lon": -104.9946048,
-    "centroid_lat": 39.7480127
+    "lng": -104.9946048,
+    "lat": 39.7480127
   },
   "80293": {
     "PO_NAME": "Denver",
@@ -923,8 +923,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0,
-    "centroid_lon": -104.9900824,
-    "centroid_lat": 39.74579664
+    "lng": -104.9900824,
+    "lat": 39.74579664
   },
   "80294": {
     "PO_NAME": "Denver",
@@ -932,8 +932,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.01,
-    "centroid_lon": -104.9892557,
-    "centroid_lat": 39.74946903
+    "lng": -104.9892557,
+    "lat": 39.74946903
   },
   "80301": {
     "PO_NAME": "Boulder",
@@ -941,8 +941,8 @@
     "POPULATION": 25614,
     "POP_SQMI": 865.05,
     "SQMI": 29.61,
-    "centroid_lon": -105.199185,
-    "centroid_lat": 40.04627914
+    "lng": -105.199185,
+    "lat": 40.04627914
   },
   "80302": {
     "PO_NAME": "Boulder",
@@ -950,8 +950,8 @@
     "POPULATION": 30007,
     "POP_SQMI": 310.12,
     "SQMI": 96.76,
-    "centroid_lon": -105.3623087,
-    "centroid_lat": 40.0336593
+    "lng": -105.3623087,
+    "lat": 40.0336593
   },
   "80303": {
     "PO_NAME": "Boulder",
@@ -959,8 +959,8 @@
     "POPULATION": 26592,
     "POP_SQMI": 848.23,
     "SQMI": 31.35,
-    "centroid_lon": -105.2236105,
-    "centroid_lat": 39.96236483
+    "lng": -105.2236105,
+    "lat": 39.96236483
   },
   "80304": {
     "PO_NAME": "Boulder",
@@ -968,8 +968,8 @@
     "POPULATION": 27595,
     "POP_SQMI": 3042.45,
     "SQMI": 9.07,
-    "centroid_lon": -105.2915076,
-    "centroid_lat": 40.04283839
+    "lng": -105.2915076,
+    "lat": 40.04283839
   },
   "80305": {
     "PO_NAME": "Boulder",
@@ -977,8 +977,8 @@
     "POPULATION": 17213,
     "POP_SQMI": 3428.88,
     "SQMI": 5.02,
-    "centroid_lon": -105.2520221,
-    "centroid_lat": 39.97855883
+    "lng": -105.2520221,
+    "lat": 39.97855883
   },
   "80309": {
     "PO_NAME": "Boulder",
@@ -986,8 +986,8 @@
     "POPULATION": 4990,
     "POP_SQMI": 29352.94,
     "SQMI": 0.17,
-    "centroid_lon": -105.2692532,
-    "centroid_lat": 40.00851431
+    "lng": -105.2692532,
+    "lat": 40.00851431
   },
   "80310": {
     "PO_NAME": "Boulder",
@@ -995,8 +995,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.22,
-    "centroid_lon": -105.2630817,
-    "centroid_lat": 40.00458071
+    "lng": -105.2630817,
+    "lat": 40.00458071
   },
   "80401": {
     "PO_NAME": "Golden",
@@ -1004,8 +1004,8 @@
     "POPULATION": 42488,
     "POP_SQMI": 843.35,
     "SQMI": 50.38,
-    "centroid_lon": -105.2316578,
-    "centroid_lat": 39.71799315
+    "lng": -105.2316578,
+    "lat": 39.71799315
   },
   "80403": {
     "PO_NAME": "Golden",
@@ -1013,8 +1013,8 @@
     "POPULATION": 21713,
     "POP_SQMI": 144.71,
     "SQMI": 150.05,
-    "centroid_lon": -105.327314,
-    "centroid_lat": 39.83396237
+    "lng": -105.327314,
+    "lat": 39.83396237
   },
   "80419": {
     "PO_NAME": "Golden",
@@ -1022,8 +1022,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.09,
-    "centroid_lon": -105.2024397,
-    "centroid_lat": 39.72849517
+    "lng": -105.2024397,
+    "lat": 39.72849517
   },
   "80420": {
     "PO_NAME": "Alma",
@@ -1031,8 +1031,8 @@
     "POPULATION": 305,
     "POP_SQMI": 897.06,
     "SQMI": 0.34,
-    "centroid_lon": -106.0655759,
-    "centroid_lat": 39.28528101
+    "lng": -106.0655759,
+    "lat": 39.28528101
   },
   "80421": {
     "PO_NAME": "Bailey",
@@ -1040,8 +1040,8 @@
     "POPULATION": 9061,
     "POP_SQMI": 33.81,
     "SQMI": 267.96,
-    "centroid_lon": -105.5568602,
-    "centroid_lat": 39.43421334
+    "lng": -105.5568602,
+    "lat": 39.43421334
   },
   "80422": {
     "PO_NAME": "Black Hawk",
@@ -1049,8 +1049,8 @@
     "POPULATION": 3815,
     "POP_SQMI": 79.98,
     "SQMI": 47.7,
-    "centroid_lon": -105.4690159,
-    "centroid_lat": 39.85718674
+    "lng": -105.4690159,
+    "lat": 39.85718674
   },
   "80423": {
     "PO_NAME": "Bond",
@@ -1058,8 +1058,8 @@
     "POPULATION": 197,
     "POP_SQMI": 0.89,
     "SQMI": 221.17,
-    "centroid_lon": -106.6624754,
-    "centroid_lat": 39.82713938
+    "lng": -106.6624754,
+    "lat": 39.82713938
   },
   "80424": {
     "PO_NAME": "Breckenridge",
@@ -1067,8 +1067,8 @@
     "POPULATION": 10678,
     "POP_SQMI": 84.61,
     "SQMI": 126.21,
-    "centroid_lon": -106.0168961,
-    "centroid_lat": 39.47091499
+    "lng": -106.0168961,
+    "lat": 39.47091499
   },
   "80425": {
     "PO_NAME": "Buffalo Creek",
@@ -1076,8 +1076,8 @@
     "POPULATION": 5,
     "POP_SQMI": 0.12,
     "SQMI": 40.75,
-    "centroid_lon": -105.2680181,
-    "centroid_lat": 39.35355954
+    "lng": -105.2680181,
+    "lat": 39.35355954
   },
   "80427": {
     "PO_NAME": "Central City",
@@ -1085,8 +1085,8 @@
     "POPULATION": 644,
     "POP_SQMI": 17.85,
     "SQMI": 36.08,
-    "centroid_lon": -105.547879,
-    "centroid_lat": 39.81879373
+    "lng": -105.547879,
+    "lat": 39.81879373
   },
   "80428": {
     "PO_NAME": "Clark",
@@ -1094,8 +1094,8 @@
     "POPULATION": 739,
     "POP_SQMI": 2.09,
     "SQMI": 353.29,
-    "centroid_lon": -106.8534919,
-    "centroid_lat": 40.74529544
+    "lng": -106.8534919,
+    "lat": 40.74529544
   },
   "80430": {
     "PO_NAME": "Coalmont",
@@ -1103,8 +1103,8 @@
     "POPULATION": 223,
     "POP_SQMI": 0.61,
     "SQMI": 364.25,
-    "centroid_lon": -106.4747251,
-    "centroid_lat": 40.52504855
+    "lng": -106.4747251,
+    "lat": 40.52504855
   },
   "80432": {
     "PO_NAME": "Como",
@@ -1112,8 +1112,8 @@
     "POPULATION": 10,
     "POP_SQMI": 0.26,
     "SQMI": 39.02,
-    "centroid_lon": -105.787921,
-    "centroid_lat": 39.19165947
+    "lng": -105.787921,
+    "lat": 39.19165947
   },
   "80433": {
     "PO_NAME": "Conifer",
@@ -1121,8 +1121,8 @@
     "POPULATION": 8618,
     "POP_SQMI": 97.58,
     "SQMI": 88.32,
-    "centroid_lon": -105.273605,
-    "centroid_lat": 39.4693651
+    "lng": -105.273605,
+    "lat": 39.4693651
   },
   "80435": {
     "PO_NAME": "Dillon",
@@ -1130,8 +1130,8 @@
     "POPULATION": 8082,
     "POP_SQMI": 66.74,
     "SQMI": 121.1,
-    "centroid_lon": -105.9345022,
-    "centroid_lat": 39.60830174
+    "lng": -105.9345022,
+    "lat": 39.60830174
   },
   "80436": {
     "PO_NAME": "Dumont",
@@ -1139,8 +1139,8 @@
     "POPULATION": 512,
     "POP_SQMI": 38.61,
     "SQMI": 13.26,
-    "centroid_lon": -105.6273639,
-    "centroid_lat": 39.77124229
+    "lng": -105.6273639,
+    "lat": 39.77124229
   },
   "80438": {
     "PO_NAME": "Empire",
@@ -1148,8 +1148,8 @@
     "POPULATION": 313,
     "POP_SQMI": 5.01,
     "SQMI": 62.42,
-    "centroid_lon": -105.7728483,
-    "centroid_lat": 39.76316576
+    "lng": -105.7728483,
+    "lat": 39.76316576
   },
   "80439": {
     "PO_NAME": "Evergreen",
@@ -1157,8 +1157,8 @@
     "POPULATION": 25823,
     "POP_SQMI": 178.92,
     "SQMI": 144.33,
-    "centroid_lon": -105.3941541,
-    "centroid_lat": 39.6378225
+    "lng": -105.3941541,
+    "lat": 39.6378225
   },
   "80440": {
     "PO_NAME": "Fairplay",
@@ -1166,8 +1166,8 @@
     "POPULATION": 3678,
     "POP_SQMI": 6.79,
     "SQMI": 542,
-    "centroid_lon": -105.9981443,
-    "centroid_lat": 39.15274487
+    "lng": -105.9981443,
+    "lat": 39.15274487
   },
   "80442": {
     "PO_NAME": "Fraser",
@@ -1175,8 +1175,8 @@
     "POPULATION": 2783,
     "POP_SQMI": 81.93,
     "SQMI": 33.97,
-    "centroid_lon": -105.7666668,
-    "centroid_lat": 39.93037207
+    "lng": -105.7666668,
+    "lat": 39.93037207
   },
   "80443": {
     "PO_NAME": "Frisco",
@@ -1184,8 +1184,8 @@
     "POPULATION": 4075,
     "POP_SQMI": 40.49,
     "SQMI": 100.64,
-    "centroid_lon": -106.1668763,
-    "centroid_lat": 39.49859709
+    "lng": -106.1668763,
+    "lat": 39.49859709
   },
   "80444": {
     "PO_NAME": "Georgetown",
@@ -1193,8 +1193,8 @@
     "POPULATION": 1107,
     "POP_SQMI": 21.04,
     "SQMI": 52.61,
-    "centroid_lon": -105.7363068,
-    "centroid_lat": 39.63807502
+    "lng": -105.7363068,
+    "lat": 39.63807502
   },
   "80446": {
     "PO_NAME": "Granby",
@@ -1202,8 +1202,8 @@
     "POPULATION": 3946,
     "POP_SQMI": 9.73,
     "SQMI": 405.46,
-    "centroid_lon": -105.8455568,
-    "centroid_lat": 40.02346275
+    "lng": -105.8455568,
+    "lat": 40.02346275
   },
   "80447": {
     "PO_NAME": "Grand Lake",
@@ -1211,8 +1211,8 @@
     "POPULATION": 2132,
     "POP_SQMI": 7.12,
     "SQMI": 299.37,
-    "centroid_lon": -105.8799355,
-    "centroid_lat": 40.29798912
+    "lng": -105.8799355,
+    "lat": 40.29798912
   },
   "80448": {
     "PO_NAME": "Grant",
@@ -1220,8 +1220,8 @@
     "POPULATION": 45,
     "POP_SQMI": 0.63,
     "SQMI": 71.51,
-    "centroid_lon": -105.753011,
-    "centroid_lat": 39.4675005
+    "lng": -105.753011,
+    "lat": 39.4675005
   },
   "80449": {
     "PO_NAME": "Hartsel",
@@ -1229,8 +1229,8 @@
     "POPULATION": 939,
     "POP_SQMI": 15.15,
     "SQMI": 61.96,
-    "centroid_lon": -105.903194,
-    "centroid_lat": 38.90429169
+    "lng": -105.903194,
+    "lat": 38.90429169
   },
   "80451": {
     "PO_NAME": "Hot Sulphur Springs",
@@ -1238,8 +1238,8 @@
     "POPULATION": 865,
     "POP_SQMI": 11.44,
     "SQMI": 75.62,
-    "centroid_lon": -106.0686932,
-    "centroid_lat": 40.10956967
+    "lng": -106.0686932,
+    "lat": 40.10956967
   },
   "80452": {
     "PO_NAME": "Idaho Springs",
@@ -1247,8 +1247,8 @@
     "POPULATION": 3844,
     "POP_SQMI": 23.97,
     "SQMI": 160.35,
-    "centroid_lon": -105.5914353,
-    "centroid_lat": 39.68517957
+    "lng": -105.5914353,
+    "lat": 39.68517957
   },
   "80453": {
     "PO_NAME": "Idledale",
@@ -1256,8 +1256,8 @@
     "POPULATION": 288,
     "POP_SQMI": 364.56,
     "SQMI": 0.79,
-    "centroid_lon": -105.2439857,
-    "centroid_lat": 39.66877328
+    "lng": -105.2439857,
+    "lat": 39.66877328
   },
   "80454": {
     "PO_NAME": "Indian Hills",
@@ -1265,8 +1265,8 @@
     "POPULATION": 1415,
     "POP_SQMI": 275.83,
     "SQMI": 5.13,
-    "centroid_lon": -105.2537723,
-    "centroid_lat": 39.63389253
+    "lng": -105.2537723,
+    "lat": 39.63389253
   },
   "80455": {
     "PO_NAME": "Jamestown",
@@ -1274,8 +1274,8 @@
     "POPULATION": 422,
     "POP_SQMI": 24.34,
     "SQMI": 17.34,
-    "centroid_lon": -105.4285475,
-    "centroid_lat": 40.08611159
+    "lng": -105.4285475,
+    "lat": 40.08611159
   },
   "80456": {
     "PO_NAME": "Jefferson",
@@ -1283,8 +1283,8 @@
     "POPULATION": 1122,
     "POP_SQMI": 5.83,
     "SQMI": 192.44,
-    "centroid_lon": -105.7770095,
-    "centroid_lat": 39.3402169
+    "lng": -105.7770095,
+    "lat": 39.3402169
   },
   "80457": {
     "PO_NAME": "Kittredge",
@@ -1292,8 +1292,8 @@
     "POPULATION": 721,
     "POP_SQMI": 1287.5,
     "SQMI": 0.56,
-    "centroid_lon": -105.3004652,
-    "centroid_lat": 39.65024806
+    "lng": -105.3004652,
+    "lat": 39.65024806
   },
   "80459": {
     "PO_NAME": "Kremmling",
@@ -1301,8 +1301,8 @@
     "POPULATION": 2499,
     "POP_SQMI": 4.54,
     "SQMI": 550.75,
-    "centroid_lon": -106.4693418,
-    "centroid_lat": 40.15799285
+    "lng": -106.4693418,
+    "lat": 40.15799285
   },
   "80461": {
     "PO_NAME": "Leadville",
@@ -1310,8 +1310,8 @@
     "POPULATION": 8059,
     "POP_SQMI": 40.43,
     "SQMI": 199.31,
-    "centroid_lon": -106.2989519,
-    "centroid_lat": 39.26711498
+    "lng": -106.2989519,
+    "lat": 39.26711498
   },
   "80463": {
     "PO_NAME": "Mc Coy",
@@ -1319,8 +1319,8 @@
     "POPULATION": 80,
     "POP_SQMI": 2.3,
     "SQMI": 34.83,
-    "centroid_lon": -106.7979548,
-    "centroid_lat": 39.8947036
+    "lng": -106.7979548,
+    "lat": 39.8947036
   },
   "80465": {
     "PO_NAME": "Morrison",
@@ -1328,8 +1328,8 @@
     "POPULATION": 16077,
     "POP_SQMI": 410.97,
     "SQMI": 39.12,
-    "centroid_lon": -105.2154495,
-    "centroid_lat": 39.60852862
+    "lng": -105.2154495,
+    "lat": 39.60852862
   },
   "80466": {
     "PO_NAME": "Nederland",
@@ -1337,8 +1337,8 @@
     "POPULATION": 3862,
     "POP_SQMI": 42.89,
     "SQMI": 90.04,
-    "centroid_lon": -105.5441418,
-    "centroid_lat": 39.97633611
+    "lng": -105.5441418,
+    "lat": 39.97633611
   },
   "80467": {
     "PO_NAME": "Oak Creek",
@@ -1346,8 +1346,8 @@
     "POPULATION": 2701,
     "POP_SQMI": 14.03,
     "SQMI": 192.57,
-    "centroid_lon": -106.8658694,
-    "centroid_lat": 40.24027231
+    "lng": -106.8658694,
+    "lat": 40.24027231
   },
   "80468": {
     "PO_NAME": "Parshall",
@@ -1355,8 +1355,8 @@
     "POPULATION": 252,
     "POP_SQMI": 0.54,
     "SQMI": 462.99,
-    "centroid_lon": -106.1283827,
-    "centroid_lat": 40.00661928
+    "lng": -106.1283827,
+    "lat": 40.00661928
   },
   "80469": {
     "PO_NAME": "Phippsburg",
@@ -1364,8 +1364,8 @@
     "POPULATION": 192,
     "POP_SQMI": 8.49,
     "SQMI": 22.62,
-    "centroid_lon": -106.9814482,
-    "centroid_lat": 40.2122586
+    "lng": -106.9814482,
+    "lat": 40.2122586
   },
   "80470": {
     "PO_NAME": "Pine",
@@ -1373,8 +1373,8 @@
     "POPULATION": 4045,
     "POP_SQMI": 61.43,
     "SQMI": 65.85,
-    "centroid_lon": -105.3590297,
-    "centroid_lat": 39.42202125
+    "lng": -105.3590297,
+    "lat": 39.42202125
   },
   "80473": {
     "PO_NAME": "Rand",
@@ -1382,8 +1382,8 @@
     "POPULATION": 32,
     "POP_SQMI": 3.24,
     "SQMI": 9.89,
-    "centroid_lon": -106.140758,
-    "centroid_lat": 40.44165824
+    "lng": -106.140758,
+    "lat": 40.44165824
   },
   "80474": {
     "PO_NAME": "Rollinsville",
@@ -1391,8 +1391,8 @@
     "POPULATION": 439,
     "POP_SQMI": 9.66,
     "SQMI": 45.43,
-    "centroid_lon": -105.6046172,
-    "centroid_lat": 39.89935765
+    "lng": -105.6046172,
+    "lat": 39.89935765
   },
   "80475": {
     "PO_NAME": "Shawnee",
@@ -1400,8 +1400,8 @@
     "POPULATION": 156,
     "POP_SQMI": 11.3,
     "SQMI": 13.8,
-    "centroid_lon": -105.5756201,
-    "centroid_lat": 39.43388864
+    "lng": -105.5756201,
+    "lat": 39.43388864
   },
   "80476": {
     "PO_NAME": "Silver Plume",
@@ -1409,8 +1409,8 @@
     "POPULATION": 184,
     "POP_SQMI": 4.19,
     "SQMI": 43.96,
-    "centroid_lon": -105.8311568,
-    "centroid_lat": 39.68811487
+    "lng": -105.8311568,
+    "lat": 39.68811487
   },
   "80478": {
     "PO_NAME": "Tabernash",
@@ -1418,8 +1418,8 @@
     "POPULATION": 2076,
     "POP_SQMI": 322.36,
     "SQMI": 6.44,
-    "centroid_lon": -105.8426914,
-    "centroid_lat": 39.97726684
+    "lng": -105.8426914,
+    "lat": 39.97726684
   },
   "80479": {
     "PO_NAME": "Toponas",
@@ -1427,8 +1427,8 @@
     "POPULATION": 371,
     "POP_SQMI": 1.11,
     "SQMI": 334.75,
-    "centroid_lon": -106.8507653,
-    "centroid_lat": 40.0385239
+    "lng": -106.8507653,
+    "lat": 40.0385239
   },
   "80480": {
     "PO_NAME": "Walden",
@@ -1436,8 +1436,8 @@
     "POPULATION": 1126,
     "POP_SQMI": 0.9,
     "SQMI": 1245.84,
-    "centroid_lon": -106.3062669,
-    "centroid_lat": 40.70960034
+    "lng": -106.3062669,
+    "lat": 40.70960034
   },
   "80481": {
     "PO_NAME": "Ward",
@@ -1445,8 +1445,8 @@
     "POPULATION": 611,
     "POP_SQMI": 6.45,
     "SQMI": 94.76,
-    "centroid_lon": -105.508805,
-    "centroid_lat": 40.10456319
+    "lng": -105.508805,
+    "lat": 40.10456319
   },
   "80482": {
     "PO_NAME": "Winter Park",
@@ -1454,8 +1454,8 @@
     "POPULATION": 1159,
     "POP_SQMI": 98.81,
     "SQMI": 11.73,
-    "centroid_lon": -105.7734009,
-    "centroid_lat": 39.8946501
+    "lng": -105.7734009,
+    "lat": 39.8946501
   },
   "80483": {
     "PO_NAME": "Yampa",
@@ -1463,8 +1463,8 @@
     "POPULATION": 458,
     "POP_SQMI": 46.5,
     "SQMI": 9.85,
-    "centroid_lon": -106.9049299,
-    "centroid_lat": 40.1443133
+    "lng": -106.9049299,
+    "lat": 40.1443133
   },
   "80487": {
     "PO_NAME": "Steamboat Springs",
@@ -1472,8 +1472,8 @@
     "POPULATION": 18947,
     "POP_SQMI": 31.88,
     "SQMI": 594.28,
-    "centroid_lon": -106.8938256,
-    "centroid_lat": 40.45693193
+    "lng": -106.8938256,
+    "lat": 40.45693193
   },
   "80498": {
     "PO_NAME": "Silverthorne",
@@ -1481,8 +1481,8 @@
     "POPULATION": 8608,
     "POP_SQMI": 22.82,
     "SQMI": 377.17,
-    "centroid_lon": -106.2929003,
-    "centroid_lat": 39.7804569
+    "lng": -106.2929003,
+    "lat": 39.7804569
   },
   "80501": {
     "PO_NAME": "Longmont",
@@ -1490,8 +1490,8 @@
     "POPULATION": 43128,
     "POP_SQMI": 3486.5,
     "SQMI": 12.37,
-    "centroid_lon": -105.1024406,
-    "centroid_lat": 40.1649311
+    "lng": -105.1024406,
+    "lat": 40.1649311
   },
   "80503": {
     "PO_NAME": "Longmont",
@@ -1499,8 +1499,8 @@
     "POPULATION": 36415,
     "POP_SQMI": 387.48,
     "SQMI": 93.98,
-    "centroid_lon": -105.200213,
-    "centroid_lat": 40.16958455
+    "lng": -105.200213,
+    "lat": 40.16958455
   },
   "80504": {
     "PO_NAME": "Longmont",
@@ -1508,8 +1508,8 @@
     "POPULATION": 60928,
     "POP_SQMI": 618.5,
     "SQMI": 98.51,
-    "centroid_lon": -105.0263328,
-    "centroid_lat": 40.1654061
+    "lng": -105.0263328,
+    "lat": 40.1654061
   },
   "80510": {
     "PO_NAME": "Allenspark",
@@ -1517,8 +1517,8 @@
     "POPULATION": 373,
     "POP_SQMI": 20.42,
     "SQMI": 18.27,
-    "centroid_lon": -105.5081876,
-    "centroid_lat": 40.23016324
+    "lng": -105.5081876,
+    "lat": 40.23016324
   },
   "80512": {
     "PO_NAME": "Bellvue",
@@ -1526,8 +1526,8 @@
     "POPULATION": 2460,
     "POP_SQMI": 5.17,
     "SQMI": 475.42,
-    "centroid_lon": -105.559171,
-    "centroid_lat": 40.62360933
+    "lng": -105.559171,
+    "lat": 40.62360933
   },
   "80513": {
     "PO_NAME": "Berthoud",
@@ -1535,8 +1535,8 @@
     "POPULATION": 15359,
     "POP_SQMI": 220.93,
     "SQMI": 69.52,
-    "centroid_lon": -105.1067527,
-    "centroid_lat": 40.29867323
+    "lng": -105.1067527,
+    "lat": 40.29867323
   },
   "80514": {
     "PO_NAME": "Dacono",
@@ -1544,8 +1544,8 @@
     "POPULATION": 6689,
     "POP_SQMI": 838.22,
     "SQMI": 7.98,
-    "centroid_lon": -104.9560736,
-    "centroid_lat": 40.07144912
+    "lng": -104.9560736,
+    "lat": 40.07144912
   },
   "80515": {
     "PO_NAME": "Drake",
@@ -1553,8 +1553,8 @@
     "POPULATION": 879,
     "POP_SQMI": 9.04,
     "SQMI": 97.25,
-    "centroid_lon": -105.3760506,
-    "centroid_lat": 40.45819095
+    "lng": -105.3760506,
+    "lat": 40.45819095
   },
   "80516": {
     "PO_NAME": "Erie",
@@ -1562,8 +1562,8 @@
     "POPULATION": 32452,
     "POP_SQMI": 813.74,
     "SQMI": 39.88,
-    "centroid_lon": -105.0169341,
-    "centroid_lat": 40.05138869
+    "lng": -105.0169341,
+    "lat": 40.05138869
   },
   "80517": {
     "PO_NAME": "Estes Park",
@@ -1571,8 +1571,8 @@
     "POPULATION": 10846,
     "POP_SQMI": 35.82,
     "SQMI": 302.76,
-    "centroid_lon": -105.6112283,
-    "centroid_lat": 40.40129335
+    "lng": -105.6112283,
+    "lat": 40.40129335
   },
   "80520": {
     "PO_NAME": "Firestone",
@@ -1580,8 +1580,8 @@
     "POPULATION": 1880,
     "POP_SQMI": 3916.67,
     "SQMI": 0.48,
-    "centroid_lon": -104.9326689,
-    "centroid_lat": 40.1132482
+    "lng": -104.9326689,
+    "lat": 40.1132482
   },
   "80521": {
     "PO_NAME": "Fort Collins",
@@ -1589,8 +1589,8 @@
     "POPULATION": 37505,
     "POP_SQMI": 2988.45,
     "SQMI": 12.55,
-    "centroid_lon": -105.1270954,
-    "centroid_lat": 40.59400263
+    "lng": -105.1270954,
+    "lat": 40.59400263
   },
   "80523": {
     "PO_NAME": "Fort Collins",
@@ -1598,8 +1598,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.36,
-    "centroid_lon": -105.085078,
-    "centroid_lat": 40.57382036
+    "lng": -105.085078,
+    "lat": 40.57382036
   },
   "80524": {
     "PO_NAME": "Fort Collins",
@@ -1607,8 +1607,8 @@
     "POPULATION": 38901,
     "POP_SQMI": 301.07,
     "SQMI": 129.21,
-    "centroid_lon": -105.0194349,
-    "centroid_lat": 40.64551591
+    "lng": -105.0194349,
+    "lat": 40.64551591
   },
   "80525": {
     "PO_NAME": "Fort Collins",
@@ -1616,8 +1616,8 @@
     "POPULATION": 58294,
     "POP_SQMI": 2143.16,
     "SQMI": 27.2,
-    "centroid_lon": -105.038492,
-    "centroid_lat": 40.52676054
+    "lng": -105.038492,
+    "lat": 40.52676054
   },
   "80526": {
     "PO_NAME": "Fort Collins",
@@ -1625,8 +1625,8 @@
     "POPULATION": 46808,
     "POP_SQMI": 1432.75,
     "SQMI": 32.67,
-    "centroid_lon": -105.1305044,
-    "centroid_lat": 40.52223999
+    "lng": -105.1305044,
+    "lat": 40.52223999
   },
   "80528": {
     "PO_NAME": "Fort Collins",
@@ -1634,8 +1634,8 @@
     "POPULATION": 22647,
     "POP_SQMI": 1214.32,
     "SQMI": 18.65,
-    "centroid_lon": -105.0000867,
-    "centroid_lat": 40.49433423
+    "lng": -105.0000867,
+    "lat": 40.49433423
   },
   "80530": {
     "PO_NAME": "Frederick",
@@ -1643,8 +1643,8 @@
     "POPULATION": 5382,
     "POP_SQMI": 1915.3,
     "SQMI": 2.81,
-    "centroid_lon": -104.9244693,
-    "centroid_lat": 40.09913736
+    "lng": -104.9244693,
+    "lat": 40.09913736
   },
   "80532": {
     "PO_NAME": "Glen Haven",
@@ -1652,8 +1652,8 @@
     "POPULATION": 138,
     "POP_SQMI": 28.63,
     "SQMI": 4.82,
-    "centroid_lon": -105.4523132,
-    "centroid_lat": 40.4632244
+    "lng": -105.4523132,
+    "lat": 40.4632244
   },
   "80534": {
     "PO_NAME": "Johnstown",
@@ -1661,8 +1661,8 @@
     "POPULATION": 18057,
     "POP_SQMI": 365.3,
     "SQMI": 49.43,
-    "centroid_lon": -104.9409652,
-    "centroid_lat": 40.33038705
+    "lng": -104.9409652,
+    "lat": 40.33038705
   },
   "80535": {
     "PO_NAME": "Laporte",
@@ -1670,8 +1670,8 @@
     "POPULATION": 2885,
     "POP_SQMI": 75.98,
     "SQMI": 37.97,
-    "centroid_lon": -105.1887102,
-    "centroid_lat": 40.72461717
+    "lng": -105.1887102,
+    "lat": 40.72461717
   },
   "80536": {
     "PO_NAME": "Livermore",
@@ -1679,8 +1679,8 @@
     "POPULATION": 1981,
     "POP_SQMI": 5.48,
     "SQMI": 361.44,
-    "centroid_lon": -105.4092685,
-    "centroid_lat": 40.87426174
+    "lng": -105.4092685,
+    "lat": 40.87426174
   },
   "80537": {
     "PO_NAME": "Loveland",
@@ -1688,8 +1688,8 @@
     "POPULATION": 45744,
     "POP_SQMI": 434,
     "SQMI": 105.4,
-    "centroid_lon": -105.1797218,
-    "centroid_lat": 40.3806952
+    "lng": -105.1797218,
+    "lat": 40.3806952
   },
   "80538": {
     "PO_NAME": "Loveland",
@@ -1697,8 +1697,8 @@
     "POPULATION": 51875,
     "POP_SQMI": 504.52,
     "SQMI": 102.82,
-    "centroid_lon": -105.160719,
-    "centroid_lat": 40.48202399
+    "lng": -105.160719,
+    "lat": 40.48202399
   },
   "80540": {
     "PO_NAME": "Lyons",
@@ -1706,8 +1706,8 @@
     "POPULATION": 4827,
     "POP_SQMI": 23.76,
     "SQMI": 203.14,
-    "centroid_lon": -105.4272511,
-    "centroid_lat": 40.23503196
+    "lng": -105.4272511,
+    "lat": 40.23503196
   },
   "80542": {
     "PO_NAME": "Mead",
@@ -1715,8 +1715,8 @@
     "POPULATION": 4866,
     "POP_SQMI": 547.36,
     "SQMI": 8.89,
-    "centroid_lon": -105.0011925,
-    "centroid_lat": 40.23292739
+    "lng": -105.0011925,
+    "lat": 40.23292739
   },
   "80543": {
     "PO_NAME": "Milliken",
@@ -1724,8 +1724,8 @@
     "POPULATION": 9181,
     "POP_SQMI": 253.41,
     "SQMI": 36.23,
-    "centroid_lon": -104.8532222,
-    "centroid_lat": 40.34456359
+    "lng": -104.8532222,
+    "lat": 40.34456359
   },
   "80544": {
     "PO_NAME": "Niwot",
@@ -1733,8 +1733,8 @@
     "POPULATION": 124,
     "POP_SQMI": 1377.78,
     "SQMI": 0.09,
-    "centroid_lon": -105.1706337,
-    "centroid_lat": 40.10425772
+    "lng": -105.1706337,
+    "lat": 40.10425772
   },
   "80545": {
     "PO_NAME": "Red Feather Lakes",
@@ -1742,8 +1742,8 @@
     "POPULATION": 1037,
     "POP_SQMI": 1.84,
     "SQMI": 564.07,
-    "centroid_lon": -105.8426754,
-    "centroid_lat": 40.84399243
+    "lng": -105.8426754,
+    "lat": 40.84399243
   },
   "80546": {
     "PO_NAME": "Severance",
@@ -1751,8 +1751,8 @@
     "POPULATION": 145,
     "POP_SQMI": 725,
     "SQMI": 0.2,
-    "centroid_lon": -104.8517316,
-    "centroid_lat": 40.52447528
+    "lng": -104.8517316,
+    "lat": 40.52447528
   },
   "80547": {
     "PO_NAME": "Timnath",
@@ -1760,8 +1760,8 @@
     "POPULATION": 4631,
     "POP_SQMI": 792.98,
     "SQMI": 5.84,
-    "centroid_lon": -104.9611195,
-    "centroid_lat": 40.53210186
+    "lng": -104.9611195,
+    "lat": 40.53210186
   },
   "80549": {
     "PO_NAME": "Wellington",
@@ -1769,8 +1769,8 @@
     "POPULATION": 13087,
     "POP_SQMI": 59.08,
     "SQMI": 221.51,
-    "centroid_lon": -105.0845371,
-    "centroid_lat": 40.84901465
+    "lng": -105.0845371,
+    "lat": 40.84901465
   },
   "80550": {
     "PO_NAME": "Windsor",
@@ -1778,8 +1778,8 @@
     "POPULATION": 37008,
     "POP_SQMI": 636.31,
     "SQMI": 58.16,
-    "centroid_lon": -104.8986623,
-    "centroid_lat": 40.47848219
+    "lng": -104.8986623,
+    "lat": 40.47848219
   },
   "80601": {
     "PO_NAME": "Brighton",
@@ -1787,8 +1787,8 @@
     "POPULATION": 41907,
     "POP_SQMI": 1497.21,
     "SQMI": 27.99,
-    "centroid_lon": -104.8098753,
-    "centroid_lat": 39.95952099
+    "lng": -104.8098753,
+    "lat": 39.95952099
   },
   "80602": {
     "PO_NAME": "Brighton",
@@ -1796,8 +1796,8 @@
     "POPULATION": 42529,
     "POP_SQMI": 1369.25,
     "SQMI": 31.06,
-    "centroid_lon": -104.9087258,
-    "centroid_lat": 39.96605133
+    "lng": -104.9087258,
+    "lat": 39.96605133
   },
   "80603": {
     "PO_NAME": "Brighton",
@@ -1805,8 +1805,8 @@
     "POPULATION": 14775,
     "POP_SQMI": 203.57,
     "SQMI": 72.58,
-    "centroid_lon": -104.7527152,
-    "centroid_lat": 39.99106071
+    "lng": -104.7527152,
+    "lat": 39.99106071
   },
   "80610": {
     "PO_NAME": "Ault",
@@ -1814,8 +1814,8 @@
     "POPULATION": 3652,
     "POP_SQMI": 16.49,
     "SQMI": 221.48,
-    "centroid_lon": -104.5725386,
-    "centroid_lat": 40.67840623
+    "lng": -104.5725386,
+    "lat": 40.67840623
   },
   "80611": {
     "PO_NAME": "Briggsdale",
@@ -1823,8 +1823,8 @@
     "POPULATION": 834,
     "POP_SQMI": 2.07,
     "SQMI": 402.46,
-    "centroid_lon": -104.2403178,
-    "centroid_lat": 40.61335296
+    "lng": -104.2403178,
+    "lat": 40.61335296
   },
   "80612": {
     "PO_NAME": "Carr",
@@ -1832,8 +1832,8 @@
     "POPULATION": 621,
     "POP_SQMI": 3.45,
     "SQMI": 180.05,
-    "centroid_lon": -104.8940982,
-    "centroid_lat": 40.88320473
+    "lng": -104.8940982,
+    "lat": 40.88320473
   },
   "80614": {
     "PO_NAME": "Eastlake",
@@ -1841,8 +1841,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.04,
-    "centroid_lon": -104.9606019,
-    "centroid_lat": 39.92352231
+    "lng": -104.9606019,
+    "lat": 39.92352231
   },
   "80615": {
     "PO_NAME": "Eaton",
@@ -1850,8 +1850,8 @@
     "POPULATION": 9792,
     "POP_SQMI": 113.2,
     "SQMI": 86.5,
-    "centroid_lon": -104.6652796,
-    "centroid_lat": 40.53379104
+    "lng": -104.6652796,
+    "lat": 40.53379104
   },
   "80620": {
     "PO_NAME": "Evans",
@@ -1859,8 +1859,8 @@
     "POPULATION": 21172,
     "POP_SQMI": 4242.89,
     "SQMI": 4.99,
-    "centroid_lon": -104.7115978,
-    "centroid_lat": 40.37605313
+    "lng": -104.7115978,
+    "lat": 40.37605313
   },
   "80621": {
     "PO_NAME": "Fort Lupton",
@@ -1868,8 +1868,8 @@
     "POPULATION": 14263,
     "POP_SQMI": 109.99,
     "SQMI": 129.67,
-    "centroid_lon": -104.7964748,
-    "centroid_lat": 40.11028656
+    "lng": -104.7964748,
+    "lat": 40.11028656
   },
   "80622": {
     "PO_NAME": "Galeton",
@@ -1877,8 +1877,8 @@
     "POPULATION": 76,
     "POP_SQMI": 3.97,
     "SQMI": 19.14,
-    "centroid_lon": -104.4579626,
-    "centroid_lat": 40.56154902
+    "lng": -104.4579626,
+    "lat": 40.56154902
   },
   "80623": {
     "PO_NAME": "Gilcrest",
@@ -1886,8 +1886,8 @@
     "POPULATION": 1029,
     "POP_SQMI": 2450,
     "SQMI": 0.42,
-    "centroid_lon": -104.7789471,
-    "centroid_lat": 40.28616539
+    "lng": -104.7789471,
+    "lat": 40.28616539
   },
   "80624": {
     "PO_NAME": "Gill",
@@ -1895,8 +1895,8 @@
     "POPULATION": 1170,
     "POP_SQMI": 26.77,
     "SQMI": 43.7,
-    "centroid_lon": -104.4821206,
-    "centroid_lat": 40.47721914
+    "lng": -104.4821206,
+    "lat": 40.47721914
   },
   "80631": {
     "PO_NAME": "Greeley",
@@ -1904,8 +1904,8 @@
     "POPULATION": 55982,
     "POP_SQMI": 532.65,
     "SQMI": 105.1,
-    "centroid_lon": -104.6724261,
-    "centroid_lat": 40.44123132
+    "lng": -104.6724261,
+    "lat": 40.44123132
   },
   "80634": {
     "PO_NAME": "Greeley",
@@ -1913,8 +1913,8 @@
     "POPULATION": 67998,
     "POP_SQMI": 1976.69,
     "SQMI": 34.4,
-    "centroid_lon": -104.781538,
-    "centroid_lat": 40.39982402
+    "lng": -104.781538,
+    "lat": 40.39982402
   },
   "80639": {
     "PO_NAME": "Greeley",
@@ -1922,8 +1922,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.26,
-    "centroid_lon": -104.7004096,
-    "centroid_lat": 40.40384718
+    "lng": -104.7004096,
+    "lat": 40.40384718
   },
   "80640": {
     "PO_NAME": "Henderson",
@@ -1931,8 +1931,8 @@
     "POPULATION": 11123,
     "POP_SQMI": 733.71,
     "SQMI": 15.16,
-    "centroid_lon": -104.8845294,
-    "centroid_lat": 39.88615904
+    "lng": -104.8845294,
+    "lat": 39.88615904
   },
   "80642": {
     "PO_NAME": "Hudson",
@@ -1940,8 +1940,8 @@
     "POPULATION": 4424,
     "POP_SQMI": 44.15,
     "SQMI": 100.21,
-    "centroid_lon": -104.6156683,
-    "centroid_lat": 40.05083242
+    "lng": -104.6156683,
+    "lat": 40.05083242
   },
   "80643": {
     "PO_NAME": "Keenesburg",
@@ -1949,8 +1949,8 @@
     "POPULATION": 3803,
     "POP_SQMI": 23.83,
     "SQMI": 159.57,
-    "centroid_lon": -104.4966389,
-    "centroid_lat": 40.08383251
+    "lng": -104.4966389,
+    "lat": 40.08383251
   },
   "80644": {
     "PO_NAME": "Kersey",
@@ -1958,8 +1958,8 @@
     "POPULATION": 3146,
     "POP_SQMI": 12.9,
     "SQMI": 243.87,
-    "centroid_lon": -104.3908439,
-    "centroid_lat": 40.3585268
+    "lng": -104.3908439,
+    "lat": 40.3585268
   },
   "80645": {
     "PO_NAME": "La Salle",
@@ -1967,8 +1967,8 @@
     "POPULATION": 4617,
     "POP_SQMI": 47.54,
     "SQMI": 97.12,
-    "centroid_lon": -104.6516458,
-    "centroid_lat": 40.2860128
+    "lng": -104.6516458,
+    "lat": 40.2860128
   },
   "80646": {
     "PO_NAME": "Lucerne",
@@ -1976,8 +1976,8 @@
     "POPULATION": 82,
     "POP_SQMI": 81.19,
     "SQMI": 1.01,
-    "centroid_lon": -104.7064125,
-    "centroid_lat": 40.48822815
+    "lng": -104.7064125,
+    "lat": 40.48822815
   },
   "80648": {
     "PO_NAME": "Nunn",
@@ -1985,8 +1985,8 @@
     "POPULATION": 1124,
     "POP_SQMI": 4.53,
     "SQMI": 248.31,
-    "centroid_lon": -104.7218768,
-    "centroid_lat": 40.8265763
+    "lng": -104.7218768,
+    "lat": 40.8265763
   },
   "80649": {
     "PO_NAME": "Orchard",
@@ -1994,8 +1994,8 @@
     "POPULATION": 435,
     "POP_SQMI": 4.04,
     "SQMI": 107.77,
-    "centroid_lon": -104.1361488,
-    "centroid_lat": 40.38696794
+    "lng": -104.1361488,
+    "lat": 40.38696794
   },
   "80650": {
     "PO_NAME": "Pierce",
@@ -2003,8 +2003,8 @@
     "POPULATION": 1901,
     "POP_SQMI": 32.06,
     "SQMI": 59.29,
-    "centroid_lon": -104.7503072,
-    "centroid_lat": 40.64905272
+    "lng": -104.7503072,
+    "lat": 40.64905272
   },
   "80651": {
     "PO_NAME": "Platteville",
@@ -2012,8 +2012,8 @@
     "POPULATION": 5278,
     "POP_SQMI": 57.73,
     "SQMI": 91.43,
-    "centroid_lon": -104.8185989,
-    "centroid_lat": 40.23725562
+    "lng": -104.8185989,
+    "lat": 40.23725562
   },
   "80652": {
     "PO_NAME": "Roggen",
@@ -2021,8 +2021,8 @@
     "POPULATION": 624,
     "POP_SQMI": 2.42,
     "SQMI": 258.23,
-    "centroid_lon": -104.2932691,
-    "centroid_lat": 40.14853439
+    "lng": -104.2932691,
+    "lat": 40.14853439
   },
   "80653": {
     "PO_NAME": "Weldona",
@@ -2030,8 +2030,8 @@
     "POPULATION": 744,
     "POP_SQMI": 5.45,
     "SQMI": 136.62,
-    "centroid_lon": -103.9744796,
-    "centroid_lat": 40.39122936
+    "lng": -103.9744796,
+    "lat": 40.39122936
   },
   "80654": {
     "PO_NAME": "Wiggins",
@@ -2039,8 +2039,8 @@
     "POPULATION": 2728,
     "POP_SQMI": 12.21,
     "SQMI": 223.38,
-    "centroid_lon": -104.0726983,
-    "centroid_lat": 40.13881073
+    "lng": -104.0726983,
+    "lat": 40.13881073
   },
   "80701": {
     "PO_NAME": "Fort Morgan",
@@ -2048,8 +2048,8 @@
     "POPULATION": 16696,
     "POP_SQMI": 26.21,
     "SQMI": 637.12,
-    "centroid_lon": -103.8234934,
-    "centroid_lat": 40.14639881
+    "lng": -103.8234934,
+    "lat": 40.14639881
   },
   "80705": {
     "PO_NAME": "Log Lane Village",
@@ -2057,8 +2057,8 @@
     "POPULATION": 1001,
     "POP_SQMI": 953.33,
     "SQMI": 1.05,
-    "centroid_lon": -103.8237135,
-    "centroid_lat": 40.27043429
+    "lng": -103.8237135,
+    "lat": 40.27043429
   },
   "80720": {
     "PO_NAME": "Akron",
@@ -2066,8 +2066,8 @@
     "POPULATION": 2695,
     "POP_SQMI": 2.48,
     "SQMI": 1085.37,
-    "centroid_lon": -103.1996709,
-    "centroid_lat": 40.0676276
+    "lng": -103.1996709,
+    "lat": 40.0676276
   },
   "80721": {
     "PO_NAME": "Amherst",
@@ -2075,8 +2075,8 @@
     "POPULATION": 133,
     "POP_SQMI": 1.48,
     "SQMI": 89.77,
-    "centroid_lon": -102.1434996,
-    "centroid_lat": 40.68249885
+    "lng": -102.1434996,
+    "lat": 40.68249885
   },
   "80722": {
     "PO_NAME": "Atwood",
@@ -2084,8 +2084,8 @@
     "POPULATION": 410,
     "POP_SQMI": 20.43,
     "SQMI": 20.07,
-    "centroid_lon": -103.2759539,
-    "centroid_lat": 40.52517322
+    "lng": -103.2759539,
+    "lat": 40.52517322
   },
   "80723": {
     "PO_NAME": "Brush",
@@ -2093,8 +2093,8 @@
     "POPULATION": 7514,
     "POP_SQMI": 33.55,
     "SQMI": 223.95,
-    "centroid_lon": -103.5653065,
-    "centroid_lat": 40.16980262
+    "lng": -103.5653065,
+    "lat": 40.16980262
   },
   "80726": {
     "PO_NAME": "Crook",
@@ -2102,8 +2102,8 @@
     "POPULATION": 392,
     "POP_SQMI": 2.39,
     "SQMI": 163.9,
-    "centroid_lon": -102.7940587,
-    "centroid_lat": 40.91387338
+    "lng": -102.7940587,
+    "lat": 40.91387338
   },
   "80727": {
     "PO_NAME": "Eckley",
@@ -2111,8 +2111,8 @@
     "POPULATION": 429,
     "POP_SQMI": 2.65,
     "SQMI": 162.08,
-    "centroid_lon": -102.5030177,
-    "centroid_lat": 40.0441333
+    "lng": -102.5030177,
+    "lat": 40.0441333
   },
   "80728": {
     "PO_NAME": "Fleming",
@@ -2120,8 +2120,8 @@
     "POPULATION": 935,
     "POP_SQMI": 2.93,
     "SQMI": 319.3,
-    "centroid_lon": -102.8858635,
-    "centroid_lat": 40.61992409
+    "lng": -102.8858635,
+    "lat": 40.61992409
   },
   "80729": {
     "PO_NAME": "Grover",
@@ -2129,8 +2129,8 @@
     "POPULATION": 574,
     "POP_SQMI": 0.93,
     "SQMI": 620.35,
-    "centroid_lon": -104.2043779,
-    "centroid_lat": 40.87544941
+    "lng": -104.2043779,
+    "lat": 40.87544941
   },
   "80731": {
     "PO_NAME": "Haxtun",
@@ -2138,8 +2138,8 @@
     "POPULATION": 1645,
     "POP_SQMI": 3.85,
     "SQMI": 427.09,
-    "centroid_lon": -102.5917247,
-    "centroid_lat": 40.6159732
+    "lng": -102.5917247,
+    "lat": 40.6159732
   },
   "80732": {
     "PO_NAME": "Hereford",
@@ -2147,8 +2147,8 @@
     "POPULATION": 18,
     "POP_SQMI": 360,
     "SQMI": 0.05,
-    "centroid_lon": -104.3054257,
-    "centroid_lat": 40.97548006
+    "lng": -104.3054257,
+    "lat": 40.97548006
   },
   "80733": {
     "PO_NAME": "Hillrose",
@@ -2156,8 +2156,8 @@
     "POPULATION": 544,
     "POP_SQMI": 13.95,
     "SQMI": 38.99,
-    "centroid_lon": -103.4565807,
-    "centroid_lat": 40.35422672
+    "lng": -103.4565807,
+    "lat": 40.35422672
   },
   "80734": {
     "PO_NAME": "Holyoke",
@@ -2165,8 +2165,8 @@
     "POPULATION": 2926,
     "POP_SQMI": 8.09,
     "SQMI": 361.46,
-    "centroid_lon": -102.2646001,
-    "centroid_lat": 40.54470272
+    "lng": -102.2646001,
+    "lat": 40.54470272
   },
   "80735": {
     "PO_NAME": "Idalia",
@@ -2174,8 +2174,8 @@
     "POPULATION": 402,
     "POP_SQMI": 1.55,
     "SQMI": 258.64,
-    "centroid_lon": -102.2346081,
-    "centroid_lat": 39.68191638
+    "lng": -102.2346081,
+    "lat": 39.68191638
   },
   "80736": {
     "PO_NAME": "Iliff",
@@ -2183,8 +2183,8 @@
     "POPULATION": 707,
     "POP_SQMI": 4.58,
     "SQMI": 154.53,
-    "centroid_lon": -103.0314795,
-    "centroid_lat": 40.79556437
+    "lng": -103.0314795,
+    "lat": 40.79556437
   },
   "80737": {
     "PO_NAME": "Julesburg",
@@ -2192,8 +2192,8 @@
     "POPULATION": 1496,
     "POP_SQMI": 6.25,
     "SQMI": 239.19,
-    "centroid_lon": -102.1827247,
-    "centroid_lat": 40.8784869
+    "lng": -102.1827247,
+    "lat": 40.8784869
   },
   "80740": {
     "PO_NAME": "Lindon",
@@ -2201,8 +2201,8 @@
     "POPULATION": 180,
     "POP_SQMI": 1.02,
     "SQMI": 175.88,
-    "centroid_lon": -103.3900782,
-    "centroid_lat": 39.69141001
+    "lng": -103.3900782,
+    "lat": 39.69141001
   },
   "80741": {
     "PO_NAME": "Merino",
@@ -2210,8 +2210,8 @@
     "POPULATION": 952,
     "POP_SQMI": 4.88,
     "SQMI": 195.25,
-    "centroid_lon": -103.458908,
-    "centroid_lat": 40.57603101
+    "lng": -103.458908,
+    "lat": 40.57603101
   },
   "80742": {
     "PO_NAME": "New Raymer",
@@ -2219,8 +2219,8 @@
     "POPULATION": 250,
     "POP_SQMI": 0.59,
     "SQMI": 425.62,
-    "centroid_lon": -103.8167772,
-    "centroid_lat": 40.74308864
+    "lng": -103.8167772,
+    "lat": 40.74308864
   },
   "80743": {
     "PO_NAME": "Otis",
@@ -2228,8 +2228,8 @@
     "POPULATION": 979,
     "POP_SQMI": 2.27,
     "SQMI": 432.2,
-    "centroid_lon": -102.9445676,
-    "centroid_lat": 40.23388493
+    "lng": -102.9445676,
+    "lat": 40.23388493
   },
   "80744": {
     "PO_NAME": "Ovid",
@@ -2237,8 +2237,8 @@
     "POPULATION": 493,
     "POP_SQMI": 3.98,
     "SQMI": 123.89,
-    "centroid_lon": -102.3800281,
-    "centroid_lat": 40.87306727
+    "lng": -102.3800281,
+    "lat": 40.87306727
   },
   "80745": {
     "PO_NAME": "Padroni",
@@ -2246,8 +2246,8 @@
     "POPULATION": 101,
     "POP_SQMI": 0.47,
     "SQMI": 214,
-    "centroid_lon": -103.4226688,
-    "centroid_lat": 40.90517896
+    "lng": -103.4226688,
+    "lat": 40.90517896
   },
   "80746": {
     "PO_NAME": "Paoli",
@@ -2255,8 +2255,8 @@
     "POPULATION": 34,
     "POP_SQMI": 5.83,
     "SQMI": 5.83,
-    "centroid_lon": -102.429578,
-    "centroid_lat": 40.61643728
+    "lng": -102.429578,
+    "lat": 40.61643728
   },
   "80747": {
     "PO_NAME": "Peetz",
@@ -2264,8 +2264,8 @@
     "POPULATION": 497,
     "POP_SQMI": 2.8,
     "SQMI": 177.32,
-    "centroid_lon": -103.1356256,
-    "centroid_lat": 40.94695619
+    "lng": -103.1356256,
+    "lat": 40.94695619
   },
   "80749": {
     "PO_NAME": "Sedgwick",
@@ -2273,8 +2273,8 @@
     "POPULATION": 382,
     "POP_SQMI": 2.04,
     "SQMI": 186.95,
-    "centroid_lon": -102.5497485,
-    "centroid_lat": 40.87402153
+    "lng": -102.5497485,
+    "lat": 40.87402153
   },
   "80750": {
     "PO_NAME": "Snyder",
@@ -2282,8 +2282,8 @@
     "POPULATION": 450,
     "POP_SQMI": 2.69,
     "SQMI": 167.52,
-    "centroid_lon": -103.5965248,
-    "centroid_lat": 40.42783339
+    "lng": -103.5965248,
+    "lat": 40.42783339
   },
   "80751": {
     "PO_NAME": "Sterling",
@@ -2291,8 +2291,8 @@
     "POPULATION": 18364,
     "POP_SQMI": 37.8,
     "SQMI": 485.8,
-    "centroid_lon": -103.2510361,
-    "centroid_lat": 40.64291501
+    "lng": -103.2510361,
+    "lat": 40.64291501
   },
   "80754": {
     "PO_NAME": "Stoneham",
@@ -2300,8 +2300,8 @@
     "POPULATION": 188,
     "POP_SQMI": 1.14,
     "SQMI": 165.5,
-    "centroid_lon": -103.6423465,
-    "centroid_lat": 40.71528019
+    "lng": -103.6423465,
+    "lat": 40.71528019
   },
   "80755": {
     "PO_NAME": "Vernon",
@@ -2309,8 +2309,8 @@
     "POPULATION": 185,
     "POP_SQMI": 1.41,
     "SQMI": 130.85,
-    "centroid_lon": -102.3663594,
-    "centroid_lat": 39.8730986
+    "lng": -102.3663594,
+    "lat": 39.8730986
   },
   "80757": {
     "PO_NAME": "Woodrow",
@@ -2318,8 +2318,8 @@
     "POPULATION": 216,
     "POP_SQMI": 0.58,
     "SQMI": 375.61,
-    "centroid_lon": -103.5967211,
-    "centroid_lat": 39.81279017
+    "lng": -103.5967211,
+    "lat": 39.81279017
   },
   "80758": {
     "PO_NAME": "Wray",
@@ -2327,8 +2327,8 @@
     "POPULATION": 3879,
     "POP_SQMI": 4.91,
     "SQMI": 789.78,
-    "centroid_lon": -102.2269886,
-    "centroid_lat": 40.12869373
+    "lng": -102.2269886,
+    "lat": 40.12869373
   },
   "80759": {
     "PO_NAME": "Yuma",
@@ -2336,8 +2336,8 @@
     "POPULATION": 4756,
     "POP_SQMI": 6.45,
     "SQMI": 737.44,
-    "centroid_lon": -102.6626847,
-    "centroid_lat": 40.09631811
+    "lng": -102.6626847,
+    "lat": 40.09631811
   },
   "80801": {
     "PO_NAME": "Anton",
@@ -2345,8 +2345,8 @@
     "POPULATION": 165,
     "POP_SQMI": 1.05,
     "SQMI": 157.49,
-    "centroid_lon": -103.1425171,
-    "centroid_lat": 39.72299799
+    "lng": -103.1425171,
+    "lat": 39.72299799
   },
   "80802": {
     "PO_NAME": "Arapahoe",
@@ -2354,8 +2354,8 @@
     "POPULATION": 272,
     "POP_SQMI": 0.63,
     "SQMI": 430.46,
-    "centroid_lon": -102.1803375,
-    "centroid_lat": 38.82453414
+    "lng": -102.1803375,
+    "lat": 38.82453414
   },
   "80804": {
     "PO_NAME": "Arriba",
@@ -2363,8 +2363,8 @@
     "POPULATION": 343,
     "POP_SQMI": 1.05,
     "SQMI": 326.51,
-    "centroid_lon": -103.2562986,
-    "centroid_lat": 39.34248905
+    "lng": -103.2562986,
+    "lat": 39.34248905
   },
   "80805": {
     "PO_NAME": "Bethune",
@@ -2372,8 +2372,8 @@
     "POPULATION": 467,
     "POP_SQMI": 3.02,
     "SQMI": 154.83,
-    "centroid_lon": -102.4476625,
-    "centroid_lat": 39.29028855
+    "lng": -102.4476625,
+    "lat": 39.29028855
   },
   "80807": {
     "PO_NAME": "Burlington",
@@ -2381,8 +2381,8 @@
     "POPULATION": 4289,
     "POP_SQMI": 6.24,
     "SQMI": 687.46,
-    "centroid_lon": -102.2260084,
-    "centroid_lat": 39.30118489
+    "lng": -102.2260084,
+    "lat": 39.30118489
   },
   "80808": {
     "PO_NAME": "Calhan",
@@ -2390,8 +2390,8 @@
     "POPULATION": 6797,
     "POP_SQMI": 19.34,
     "SQMI": 351.46,
-    "centroid_lon": -104.312303,
-    "centroid_lat": 38.99451296
+    "lng": -104.312303,
+    "lat": 38.99451296
   },
   "80809": {
     "PO_NAME": "Cascade",
@@ -2399,8 +2399,8 @@
     "POPULATION": 1814,
     "POP_SQMI": 74.8,
     "SQMI": 24.25,
-    "centroid_lon": -104.9745945,
-    "centroid_lat": 38.90165286
+    "lng": -104.9745945,
+    "lat": 38.90165286
   },
   "80810": {
     "PO_NAME": "Cheyenne Wells",
@@ -2408,8 +2408,8 @@
     "POPULATION": 1144,
     "POP_SQMI": 3.24,
     "SQMI": 353.14,
-    "centroid_lon": -102.42367,
-    "centroid_lat": 38.8316405
+    "lng": -102.42367,
+    "lat": 38.8316405
   },
   "80812": {
     "PO_NAME": "Cope",
@@ -2417,8 +2417,8 @@
     "POPULATION": 384,
     "POP_SQMI": 1.54,
     "SQMI": 248.78,
-    "centroid_lon": -102.9878837,
-    "centroid_lat": 39.65673884
+    "lng": -102.9878837,
+    "lat": 39.65673884
   },
   "80813": {
     "PO_NAME": "Cripple Creek",
@@ -2426,8 +2426,8 @@
     "POPULATION": 527,
     "POP_SQMI": 22.37,
     "SQMI": 23.56,
-    "centroid_lon": -105.1862018,
-    "centroid_lat": 38.79572064
+    "lng": -105.1862018,
+    "lat": 38.79572064
   },
   "80814": {
     "PO_NAME": "Divide",
@@ -2435,8 +2435,8 @@
     "POPULATION": 4498,
     "POP_SQMI": 40.32,
     "SQMI": 111.57,
-    "centroid_lon": -105.1665848,
-    "centroid_lat": 38.93451964
+    "lng": -105.1665848,
+    "lat": 38.93451964
   },
   "80815": {
     "PO_NAME": "Flagler",
@@ -2444,8 +2444,8 @@
     "POPULATION": 839,
     "POP_SQMI": 1.84,
     "SQMI": 455.97,
-    "centroid_lon": -103.0366909,
-    "centroid_lat": 39.30357023
+    "lng": -103.0366909,
+    "lat": 39.30357023
   },
   "80816": {
     "PO_NAME": "Florissant",
@@ -2453,8 +2453,8 @@
     "POPULATION": 7812,
     "POP_SQMI": 23.8,
     "SQMI": 328.25,
-    "centroid_lon": -105.2089225,
-    "centroid_lat": 38.79264161
+    "lng": -105.2089225,
+    "lat": 38.79264161
   },
   "80817": {
     "PO_NAME": "Fountain",
@@ -2462,8 +2462,8 @@
     "POPULATION": 33579,
     "POP_SQMI": 290.02,
     "SQMI": 115.78,
-    "centroid_lon": -104.6539893,
-    "centroid_lat": 38.61083772
+    "lng": -104.6539893,
+    "lat": 38.61083772
   },
   "80818": {
     "PO_NAME": "Genoa",
@@ -2471,8 +2471,8 @@
     "POPULATION": 383,
     "POP_SQMI": 1.42,
     "SQMI": 269.44,
-    "centroid_lon": -103.4602932,
-    "centroid_lat": 39.41352073
+    "lng": -103.4602932,
+    "lat": 39.41352073
   },
   "80819": {
     "PO_NAME": "Green Mountain Falls",
@@ -2480,8 +2480,8 @@
     "POPULATION": 726,
     "POP_SQMI": 87.15,
     "SQMI": 8.33,
-    "centroid_lon": -104.9927688,
-    "centroid_lat": 38.955152
+    "lng": -104.9927688,
+    "lat": 38.955152
   },
   "80820": {
     "PO_NAME": "Guffey",
@@ -2489,8 +2489,8 @@
     "POPULATION": 859,
     "POP_SQMI": 1.68,
     "SQMI": 511.27,
-    "centroid_lon": -105.6595084,
-    "centroid_lat": 38.8261594
+    "lng": -105.6595084,
+    "lat": 38.8261594
   },
   "80821": {
     "PO_NAME": "Hugo",
@@ -2498,8 +2498,8 @@
     "POPULATION": 1081,
     "POP_SQMI": 1.71,
     "SQMI": 630.66,
-    "centroid_lon": -103.4881987,
-    "centroid_lat": 38.99421659
+    "lng": -103.4881987,
+    "lat": 38.99421659
   },
   "80822": {
     "PO_NAME": "Joes",
@@ -2507,8 +2507,8 @@
     "POPULATION": 238,
     "POP_SQMI": 1.99,
     "SQMI": 119.37,
-    "centroid_lon": -102.6858275,
-    "centroid_lat": 39.6651303
+    "lng": -102.6858275,
+    "lat": 39.6651303
   },
   "80823": {
     "PO_NAME": "Karval",
@@ -2516,8 +2516,8 @@
     "POPULATION": 299,
     "POP_SQMI": 0.5,
     "SQMI": 593.34,
-    "centroid_lon": -103.3821706,
-    "centroid_lat": 38.721058
+    "lng": -103.3821706,
+    "lat": 38.721058
   },
   "80824": {
     "PO_NAME": "Kirk",
@@ -2525,8 +2525,8 @@
     "POPULATION": 252,
     "POP_SQMI": 1.73,
     "SQMI": 145.54,
-    "centroid_lon": -102.4976005,
-    "centroid_lat": 39.65741384
+    "lng": -102.4976005,
+    "lat": 39.65741384
   },
   "80825": {
     "PO_NAME": "Kit Carson",
@@ -2534,8 +2534,8 @@
     "POPULATION": 437,
     "POP_SQMI": 0.45,
     "SQMI": 978.47,
-    "centroid_lon": -102.8437453,
-    "centroid_lat": 38.8313777
+    "lng": -102.8437453,
+    "lat": 38.8313777
   },
   "80827": {
     "PO_NAME": "Lake George",
@@ -2543,8 +2543,8 @@
     "POPULATION": 993,
     "POP_SQMI": 2.12,
     "SQMI": 469.08,
-    "centroid_lon": -105.5183506,
-    "centroid_lat": 39.09808644
+    "lng": -105.5183506,
+    "lat": 39.09808644
   },
   "80828": {
     "PO_NAME": "Limon",
@@ -2552,8 +2552,8 @@
     "POPULATION": 3495,
     "POP_SQMI": 8.12,
     "SQMI": 430.5,
-    "centroid_lon": -103.6896476,
-    "centroid_lat": 39.28389525
+    "lng": -103.6896476,
+    "lat": 39.28389525
   },
   "80829": {
     "PO_NAME": "Manitou Springs",
@@ -2561,8 +2561,8 @@
     "POPULATION": 5626,
     "POP_SQMI": 287.19,
     "SQMI": 19.59,
-    "centroid_lon": -104.9312719,
-    "centroid_lat": 38.82912587
+    "lng": -104.9312719,
+    "lat": 38.82912587
   },
   "80830": {
     "PO_NAME": "Matheson",
@@ -2570,8 +2570,8 @@
     "POPULATION": 241,
     "POP_SQMI": 1.32,
     "SQMI": 182.97,
-    "centroid_lon": -103.8841587,
-    "centroid_lat": 39.0926128
+    "lng": -103.8841587,
+    "lat": 39.0926128
   },
   "80831": {
     "PO_NAME": "Peyton",
@@ -2579,8 +2579,8 @@
     "POPULATION": 30801,
     "POP_SQMI": 182.08,
     "SQMI": 169.16,
-    "centroid_lon": -104.512041,
-    "centroid_lat": 38.98117048
+    "lng": -104.512041,
+    "lat": 38.98117048
   },
   "80832": {
     "PO_NAME": "Ramah",
@@ -2588,8 +2588,8 @@
     "POPULATION": 891,
     "POP_SQMI": 2.89,
     "SQMI": 308.53,
-    "centroid_lon": -104.0431057,
-    "centroid_lat": 39.06474296
+    "lng": -104.0431057,
+    "lat": 39.06474296
   },
   "80833": {
     "PO_NAME": "Rush",
@@ -2597,8 +2597,8 @@
     "POPULATION": 731,
     "POP_SQMI": 1.82,
     "SQMI": 400.96,
-    "centroid_lon": -103.9651798,
-    "centroid_lat": 38.73452776
+    "lng": -103.9651798,
+    "lat": 38.73452776
   },
   "80834": {
     "PO_NAME": "Seibert",
@@ -2606,8 +2606,8 @@
     "POPULATION": 339,
     "POP_SQMI": 1.7,
     "SQMI": 199.24,
-    "centroid_lon": -102.8761669,
-    "centroid_lat": 39.32197179
+    "lng": -102.8761669,
+    "lat": 39.32197179
   },
   "80835": {
     "PO_NAME": "Simla",
@@ -2615,8 +2615,8 @@
     "POPULATION": 979,
     "POP_SQMI": 7.83,
     "SQMI": 125.09,
-    "centroid_lon": -104.0703103,
-    "centroid_lat": 39.1741243
+    "lng": -104.0703103,
+    "lat": 39.1741243
   },
   "80836": {
     "PO_NAME": "Stratton",
@@ -2624,8 +2624,8 @@
     "POPULATION": 1189,
     "POP_SQMI": 3.19,
     "SQMI": 372.55,
-    "centroid_lon": -102.57525,
-    "centroid_lat": 39.31705278
+    "lng": -102.57525,
+    "lat": 39.31705278
   },
   "80840": {
     "PO_NAME": "Usaf Academy",
@@ -2633,8 +2633,8 @@
     "POPULATION": 7197,
     "POP_SQMI": 249.72,
     "SQMI": 28.82,
-    "centroid_lon": -104.8567735,
-    "centroid_lat": 38.99492794
+    "lng": -104.8567735,
+    "lat": 38.99492794
   },
   "80860": {
     "PO_NAME": "Victor",
@@ -2642,8 +2642,8 @@
     "POPULATION": 595,
     "POP_SQMI": 1652.78,
     "SQMI": 0.36,
-    "centroid_lon": -105.1409111,
-    "centroid_lat": 38.70969564
+    "lng": -105.1409111,
+    "lat": 38.70969564
   },
   "80861": {
     "PO_NAME": "Vona",
@@ -2651,8 +2651,8 @@
     "POPULATION": 255,
     "POP_SQMI": 0.87,
     "SQMI": 291.56,
-    "centroid_lon": -102.7439294,
-    "centroid_lat": 39.30020912
+    "lng": -102.7439294,
+    "lat": 39.30020912
   },
   "80862": {
     "PO_NAME": "Wild Horse",
@@ -2660,8 +2660,8 @@
     "POPULATION": 64,
     "POP_SQMI": 1280,
     "SQMI": 0.05,
-    "centroid_lon": -103.0062068,
-    "centroid_lat": 38.82519236
+    "lng": -103.0062068,
+    "lat": 38.82519236
   },
   "80863": {
     "PO_NAME": "Woodland Park",
@@ -2669,8 +2669,8 @@
     "POPULATION": 13426,
     "POP_SQMI": 107.42,
     "SQMI": 124.99,
-    "centroid_lon": -105.0760856,
-    "centroid_lat": 39.01402349
+    "lng": -105.0760856,
+    "lat": 39.01402349
   },
   "80864": {
     "PO_NAME": "Yoder",
@@ -2678,8 +2678,8 @@
     "POPULATION": 1528,
     "POP_SQMI": 5.85,
     "SQMI": 261.15,
-    "centroid_lon": -104.1994331,
-    "centroid_lat": 38.71917439
+    "lng": -104.1994331,
+    "lat": 38.71917439
   },
   "80902": {
     "PO_NAME": "Colorado Springs",
@@ -2687,8 +2687,8 @@
     "POPULATION": 8934,
     "POP_SQMI": 3358.65,
     "SQMI": 2.66,
-    "centroid_lon": -104.804638,
-    "centroid_lat": 38.73728406
+    "lng": -104.804638,
+    "lat": 38.73728406
   },
   "80903": {
     "PO_NAME": "Colorado Springs",
@@ -2696,8 +2696,8 @@
     "POPULATION": 16086,
     "POP_SQMI": 3904.37,
     "SQMI": 4.12,
-    "centroid_lon": -104.8168498,
-    "centroid_lat": 38.83332013
+    "lng": -104.8168498,
+    "lat": 38.83332013
   },
   "80904": {
     "PO_NAME": "Colorado Springs",
@@ -2705,8 +2705,8 @@
     "POPULATION": 22727,
     "POP_SQMI": 1630.34,
     "SQMI": 13.94,
-    "centroid_lon": -104.8766998,
-    "centroid_lat": 38.86983525
+    "lng": -104.8766998,
+    "lat": 38.86983525
   },
   "80905": {
     "PO_NAME": "Colorado Springs",
@@ -2714,8 +2714,8 @@
     "POPULATION": 18910,
     "POP_SQMI": 3766.93,
     "SQMI": 5.02,
-    "centroid_lon": -104.8357597,
-    "centroid_lat": 38.81750436
+    "lng": -104.8357597,
+    "lat": 38.81750436
   },
   "80906": {
     "PO_NAME": "Colorado Springs",
@@ -2723,8 +2723,8 @@
     "POPULATION": 39386,
     "POP_SQMI": 809.58,
     "SQMI": 48.65,
-    "centroid_lon": -104.873177,
-    "centroid_lat": 38.76423718
+    "lng": -104.873177,
+    "lat": 38.76423718
   },
   "80907": {
     "PO_NAME": "Colorado Springs",
@@ -2732,8 +2732,8 @@
     "POPULATION": 27018,
     "POP_SQMI": 2718.11,
     "SQMI": 9.94,
-    "centroid_lon": -104.824264,
-    "centroid_lat": 38.87875648
+    "lng": -104.824264,
+    "lat": 38.87875648
   },
   "80908": {
     "PO_NAME": "Colorado Springs",
@@ -2741,8 +2741,8 @@
     "POPULATION": 22061,
     "POP_SQMI": 227.18,
     "SQMI": 97.11,
-    "centroid_lon": -104.6905646,
-    "centroid_lat": 39.04137688
+    "lng": -104.6905646,
+    "lat": 39.04137688
   },
   "80909": {
     "PO_NAME": "Colorado Springs",
@@ -2750,8 +2750,8 @@
     "POPULATION": 39555,
     "POP_SQMI": 4975.47,
     "SQMI": 7.95,
-    "centroid_lon": -104.7741732,
-    "centroid_lat": 38.8526585
+    "lng": -104.7741732,
+    "lat": 38.8526585
   },
   "80910": {
     "PO_NAME": "Colorado Springs",
@@ -2759,8 +2759,8 @@
     "POPULATION": 32486,
     "POP_SQMI": 4627.64,
     "SQMI": 7.02,
-    "centroid_lon": -104.775314,
-    "centroid_lat": 38.81161124
+    "lng": -104.775314,
+    "lat": 38.81161124
   },
   "80911": {
     "PO_NAME": "Colorado Springs",
@@ -2768,8 +2768,8 @@
     "POPULATION": 34734,
     "POP_SQMI": 2550.22,
     "SQMI": 13.62,
-    "centroid_lon": -104.7167853,
-    "centroid_lat": 38.75639619
+    "lng": -104.7167853,
+    "lat": 38.75639619
   },
   "80912": {
     "PO_NAME": "Colorado Springs",
@@ -2777,8 +2777,8 @@
     "POPULATION": 351,
     "POP_SQMI": 487.5,
     "SQMI": 0.72,
-    "centroid_lon": -104.5264467,
-    "centroid_lat": 38.80313722
+    "lng": -104.5264467,
+    "lat": 38.80313722
   },
   "80913": {
     "PO_NAME": "Colorado Springs",
@@ -2786,8 +2786,8 @@
     "POPULATION": 8147,
     "POP_SQMI": 63.03,
     "SQMI": 129.25,
-    "centroid_lon": -104.8093897,
-    "centroid_lat": 38.61213393
+    "lng": -104.8093897,
+    "lat": 38.61213393
   },
   "80914": {
     "PO_NAME": "Colorado Springs",
@@ -2795,8 +2795,8 @@
     "POPULATION": 543,
     "POP_SQMI": 631.4,
     "SQMI": 0.86,
-    "centroid_lon": -104.7053869,
-    "centroid_lat": 38.82804512
+    "lng": -104.7053869,
+    "lat": 38.82804512
   },
   "80915": {
     "PO_NAME": "Colorado Springs",
@@ -2804,8 +2804,8 @@
     "POPULATION": 21699,
     "POP_SQMI": 2992.97,
     "SQMI": 7.25,
-    "centroid_lon": -104.7165898,
-    "centroid_lat": 38.85357659
+    "lng": -104.7165898,
+    "lat": 38.85357659
   },
   "80916": {
     "PO_NAME": "Colorado Springs",
@@ -2813,8 +2813,8 @@
     "POPULATION": 37897,
     "POP_SQMI": 2235.81,
     "SQMI": 16.95,
-    "centroid_lon": -104.712533,
-    "centroid_lat": 38.80593374
+    "lng": -104.712533,
+    "lat": 38.80593374
   },
   "80917": {
     "PO_NAME": "Colorado Springs",
@@ -2822,8 +2822,8 @@
     "POPULATION": 31530,
     "POP_SQMI": 5228.86,
     "SQMI": 6.03,
-    "centroid_lon": -104.7442155,
-    "centroid_lat": 38.88611811
+    "lng": -104.7442155,
+    "lat": 38.88611811
   },
   "80918": {
     "PO_NAME": "Colorado Springs",
@@ -2831,8 +2831,8 @@
     "POPULATION": 49076,
     "POP_SQMI": 4042.5,
     "SQMI": 12.14,
-    "centroid_lon": -104.7801476,
-    "centroid_lat": 38.911748
+    "lng": -104.7801476,
+    "lat": 38.911748
   },
   "80919": {
     "PO_NAME": "Colorado Springs",
@@ -2840,8 +2840,8 @@
     "POPULATION": 30246,
     "POP_SQMI": 2085.93,
     "SQMI": 14.5,
-    "centroid_lon": -104.8549805,
-    "centroid_lat": 38.92737875
+    "lng": -104.8549805,
+    "lat": 38.92737875
   },
   "80920": {
     "PO_NAME": "Colorado Springs",
@@ -2849,8 +2849,8 @@
     "POPULATION": 41550,
     "POP_SQMI": 3494.53,
     "SQMI": 11.89,
-    "centroid_lon": -104.7697952,
-    "centroid_lat": 38.95558989
+    "lng": -104.7697952,
+    "lat": 38.95558989
   },
   "80921": {
     "PO_NAME": "Colorado Springs",
@@ -2858,8 +2858,8 @@
     "POPULATION": 28023,
     "POP_SQMI": 371.66,
     "SQMI": 75.4,
-    "centroid_lon": -104.9226412,
-    "centroid_lat": 39.05686728
+    "lng": -104.9226412,
+    "lat": 39.05686728
   },
   "80922": {
     "PO_NAME": "Colorado Springs",
@@ -2867,8 +2867,8 @@
     "POPULATION": 29603,
     "POP_SQMI": 4917.44,
     "SQMI": 6.02,
-    "centroid_lon": -104.7015935,
-    "centroid_lat": 38.88999828
+    "lng": -104.7015935,
+    "lat": 38.88999828
   },
   "80923": {
     "PO_NAME": "Colorado Springs",
@@ -2876,8 +2876,8 @@
     "POPULATION": 33053,
     "POP_SQMI": 4933.28,
     "SQMI": 6.7,
-    "centroid_lon": -104.7142923,
-    "centroid_lat": 38.92664854
+    "lng": -104.7142923,
+    "lat": 38.92664854
   },
   "80924": {
     "PO_NAME": "Colorado Springs",
@@ -2885,8 +2885,8 @@
     "POPULATION": 14202,
     "POP_SQMI": 2509.19,
     "SQMI": 5.66,
-    "centroid_lon": -104.7212795,
-    "centroid_lat": 38.96688126
+    "lng": -104.7212795,
+    "lat": 38.96688126
   },
   "80925": {
     "PO_NAME": "Colorado Springs",
@@ -2894,8 +2894,8 @@
     "POPULATION": 13209,
     "POP_SQMI": 620.72,
     "SQMI": 21.28,
-    "centroid_lon": -104.6411506,
-    "centroid_lat": 38.73998583
+    "lng": -104.6411506,
+    "lat": 38.73998583
   },
   "80926": {
     "PO_NAME": "Colorado Springs",
@@ -2903,8 +2903,8 @@
     "POPULATION": 1448,
     "POP_SQMI": 35.29,
     "SQMI": 41.03,
-    "centroid_lon": -104.8922683,
-    "centroid_lat": 38.66339799
+    "lng": -104.8922683,
+    "lat": 38.66339799
   },
   "80927": {
     "PO_NAME": "Colorado Springs",
@@ -2912,8 +2912,8 @@
     "POPULATION": 6888,
     "POP_SQMI": 4004.65,
     "SQMI": 1.72,
-    "centroid_lon": -104.6736866,
-    "centroid_lat": 38.92534995
+    "lng": -104.6736866,
+    "lat": 38.92534995
   },
   "80928": {
     "PO_NAME": "Colorado Springs",
@@ -2921,8 +2921,8 @@
     "POPULATION": 1056,
     "POP_SQMI": 4.28,
     "SQMI": 246.66,
-    "centroid_lon": -104.414159,
-    "centroid_lat": 38.63142018
+    "lng": -104.414159,
+    "lat": 38.63142018
   },
   "80929": {
     "PO_NAME": "Colorado Springs",
@@ -2930,8 +2930,8 @@
     "POPULATION": 252,
     "POP_SQMI": 6.11,
     "SQMI": 41.22,
-    "centroid_lon": -104.6078524,
-    "centroid_lat": 38.81758122
+    "lng": -104.6078524,
+    "lat": 38.81758122
   },
   "80930": {
     "PO_NAME": "Colorado Springs",
@@ -2939,8 +2939,8 @@
     "POPULATION": 1060,
     "POP_SQMI": 26.27,
     "SQMI": 40.35,
-    "centroid_lon": -104.4975597,
-    "centroid_lat": 38.80332817
+    "lng": -104.4975597,
+    "lat": 38.80332817
   },
   "80938": {
     "PO_NAME": "Colorado Springs",
@@ -2948,8 +2948,8 @@
     "POPULATION": 34,
     "POP_SQMI": 33.01,
     "SQMI": 1.03,
-    "centroid_lon": -104.6765553,
-    "centroid_lat": 38.90206361
+    "lng": -104.6765553,
+    "lat": 38.90206361
   },
   "80939": {
     "PO_NAME": "Colorado Springs",
@@ -2957,8 +2957,8 @@
     "POPULATION": 0,
     "POP_SQMI": 0,
     "SQMI": 0.62,
-    "centroid_lon": -104.6779385,
-    "centroid_lat": 38.87706422
+    "lng": -104.6779385,
+    "lat": 38.87706422
   },
   "80951": {
     "PO_NAME": "Colorado Springs",
@@ -2966,8 +2966,8 @@
     "POPULATION": 4670,
     "POP_SQMI": 450.77,
     "SQMI": 10.36,
-    "centroid_lon": -104.6526006,
-    "centroid_lat": 38.88824796
+    "lng": -104.6526006,
+    "lat": 38.88824796
   },
   "81001": {
     "PO_NAME": "Pueblo",
@@ -2975,8 +2975,8 @@
     "POPULATION": 31455,
     "POP_SQMI": 438.46,
     "SQMI": 71.74,
-    "centroid_lon": -104.4674786,
-    "centroid_lat": 38.32388918
+    "lng": -104.4674786,
+    "lat": 38.32388918
   },
   "81003": {
     "PO_NAME": "Pueblo",
@@ -2984,8 +2984,8 @@
     "POPULATION": 15544,
     "POP_SQMI": 1680.43,
     "SQMI": 9.25,
-    "centroid_lon": -104.6374835,
-    "centroid_lat": 38.27848053
+    "lng": -104.6374835,
+    "lat": 38.27848053
   },
   "81004": {
     "PO_NAME": "Pueblo",
@@ -2993,8 +2993,8 @@
     "POPULATION": 27030,
     "POP_SQMI": 147.05,
     "SQMI": 183.81,
-    "centroid_lon": -104.7462869,
-    "centroid_lat": 38.05162526
+    "lng": -104.7462869,
+    "lat": 38.05162526
   },
   "81005": {
     "PO_NAME": "Pueblo",
@@ -3002,8 +3002,8 @@
     "POPULATION": 31549,
     "POP_SQMI": 160.08,
     "SQMI": 197.08,
-    "centroid_lon": -104.8475356,
-    "centroid_lat": 38.2117363
+    "lng": -104.8475356,
+    "lat": 38.2117363
   },
   "81006": {
     "PO_NAME": "Pueblo",
@@ -3011,8 +3011,8 @@
     "POPULATION": 12788,
     "POP_SQMI": 157.82,
     "SQMI": 81.03,
-    "centroid_lon": -104.4934972,
-    "centroid_lat": 38.22769699
+    "lng": -104.4934972,
+    "lat": 38.22769699
   },
   "81007": {
     "PO_NAME": "Pueblo",
@@ -3020,8 +3020,8 @@
     "POPULATION": 32737,
     "POP_SQMI": 131.07,
     "SQMI": 249.77,
-    "centroid_lon": -104.7872437,
-    "centroid_lat": 38.40112249
+    "lng": -104.7872437,
+    "lat": 38.40112249
   },
   "81008": {
     "PO_NAME": "Pueblo",
@@ -3029,8 +3029,8 @@
     "POPULATION": 11162,
     "POP_SQMI": 102.21,
     "SQMI": 109.21,
-    "centroid_lon": -104.5794709,
-    "centroid_lat": 38.43517707
+    "lng": -104.5794709,
+    "lat": 38.43517707
   },
   "81019": {
     "PO_NAME": "Colorado City",
@@ -3038,8 +3038,8 @@
     "POPULATION": 2407,
     "POP_SQMI": 191.49,
     "SQMI": 12.57,
-    "centroid_lon": -104.8170703,
-    "centroid_lat": 37.95808663
+    "lng": -104.8170703,
+    "lat": 37.95808663
   },
   "81020": {
     "PO_NAME": "Aguilar",
@@ -3047,8 +3047,8 @@
     "POPULATION": 906,
     "POP_SQMI": 3.98,
     "SQMI": 227.61,
-    "centroid_lon": -104.7248086,
-    "centroid_lat": 37.37432784
+    "lng": -104.7248086,
+    "lat": 37.37432784
   },
   "81021": {
     "PO_NAME": "Arlington",
@@ -3056,8 +3056,8 @@
     "POPULATION": 17,
     "POP_SQMI": 0.07,
     "SQMI": 244.87,
-    "centroid_lon": -103.3663649,
-    "centroid_lat": 38.38956487
+    "lng": -103.3663649,
+    "lat": 38.38956487
   },
   "81022": {
     "PO_NAME": "Avondale",
@@ -3065,8 +3065,8 @@
     "POPULATION": 1604,
     "POP_SQMI": 7.11,
     "SQMI": 225.75,
-    "centroid_lon": -104.4948498,
-    "centroid_lat": 38.08206526
+    "lng": -104.4948498,
+    "lat": 38.08206526
   },
   "81023": {
     "PO_NAME": "Beulah",
@@ -3074,8 +3074,8 @@
     "POPULATION": 1197,
     "POP_SQMI": 9.51,
     "SQMI": 125.91,
-    "centroid_lon": -104.9432411,
-    "centroid_lat": 38.08096659
+    "lng": -104.9432411,
+    "lat": 38.08096659
   },
   "81024": {
     "PO_NAME": "Boncarbo",
@@ -3083,8 +3083,8 @@
     "POPULATION": 193,
     "POP_SQMI": 6.42,
     "SQMI": 30.04,
-    "centroid_lon": -104.688092,
-    "centroid_lat": 37.20197253
+    "lng": -104.688092,
+    "lat": 37.20197253
   },
   "81025": {
     "PO_NAME": "Boone",
@@ -3092,8 +3092,8 @@
     "POPULATION": 1133,
     "POP_SQMI": 2.21,
     "SQMI": 512.21,
-    "centroid_lon": -104.2553752,
-    "centroid_lat": 38.35518003
+    "lng": -104.2553752,
+    "lat": 38.35518003
   },
   "81027": {
     "PO_NAME": "Branson",
@@ -3101,8 +3101,8 @@
     "POPULATION": 163,
     "POP_SQMI": 0.27,
     "SQMI": 604.65,
-    "centroid_lon": -103.7678141,
-    "centroid_lat": 37.20482387
+    "lng": -103.7678141,
+    "lat": 37.20482387
   },
   "81029": {
     "PO_NAME": "Campo",
@@ -3110,8 +3110,8 @@
     "POPULATION": 358,
     "POP_SQMI": 0.72,
     "SQMI": 498.27,
-    "centroid_lon": -102.5323333,
-    "centroid_lat": 37.1048003
+    "lng": -102.5323333,
+    "lat": 37.1048003
   },
   "81030": {
     "PO_NAME": "Cheraw",
@@ -3119,8 +3119,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.09,
-    "centroid_lon": -103.5119796,
-    "centroid_lat": 38.10687357
+    "lng": -103.5119796,
+    "lat": 38.10687357
   },
   "81033": {
     "PO_NAME": "Crowley",
@@ -3128,8 +3128,8 @@
     "POPULATION": 17,
     "POP_SQMI": 62.96,
     "SQMI": 0.27,
-    "centroid_lon": -103.8547308,
-    "centroid_lat": 38.19544436
+    "lng": -103.8547308,
+    "lat": 38.19544436
   },
   "81036": {
     "PO_NAME": "Eads",
@@ -3137,8 +3137,8 @@
     "POPULATION": 998,
     "POP_SQMI": 1.54,
     "SQMI": 648.61,
-    "centroid_lon": -102.7726972,
-    "centroid_lat": 38.44449306
+    "lng": -102.7726972,
+    "lat": 38.44449306
   },
   "81039": {
     "PO_NAME": "Fowler",
@@ -3146,8 +3146,8 @@
     "POPULATION": 1977,
     "POP_SQMI": 3.26,
     "SQMI": 605.7,
-    "centroid_lon": -104.2161726,
-    "centroid_lat": 37.95819435
+    "lng": -104.2161726,
+    "lat": 37.95819435
   },
   "81040": {
     "PO_NAME": "Gardner",
@@ -3155,8 +3155,8 @@
     "POPULATION": 632,
     "POP_SQMI": 1.94,
     "SQMI": 325.86,
-    "centroid_lon": -105.3002594,
-    "centroid_lat": 37.7723711
+    "lng": -105.3002594,
+    "lat": 37.7723711
   },
   "81041": {
     "PO_NAME": "Granada",
@@ -3164,8 +3164,8 @@
     "POPULATION": 755,
     "POP_SQMI": 1.96,
     "SQMI": 384.51,
-    "centroid_lon": -102.3832432,
-    "centroid_lat": 37.84714247
+    "lng": -102.3832432,
+    "lat": 37.84714247
   },
   "81044": {
     "PO_NAME": "Hasty",
@@ -3173,8 +3173,8 @@
     "POPULATION": 172,
     "POP_SQMI": 1,
     "SQMI": 172.33,
-    "centroid_lon": -102.9214867,
-    "centroid_lat": 37.98716025
+    "lng": -102.9214867,
+    "lat": 37.98716025
   },
   "81045": {
     "PO_NAME": "Haswell",
@@ -3182,8 +3182,8 @@
     "POPULATION": 127,
     "POP_SQMI": 0.42,
     "SQMI": 301.96,
-    "centroid_lon": -103.1371005,
-    "centroid_lat": 38.46616113
+    "lng": -103.1371005,
+    "lat": 38.46616113
   },
   "81047": {
     "PO_NAME": "Holly",
@@ -3191,8 +3191,8 @@
     "POPULATION": 1606,
     "POP_SQMI": 2.39,
     "SQMI": 673.25,
-    "centroid_lon": -102.2015887,
-    "centroid_lat": 38.00760513
+    "lng": -102.2015887,
+    "lat": 38.00760513
   },
   "81049": {
     "PO_NAME": "Kim",
@@ -3200,8 +3200,8 @@
     "POPULATION": 265,
     "POP_SQMI": 0.22,
     "SQMI": 1184.46,
-    "centroid_lon": -103.3692562,
-    "centroid_lat": 37.33395632
+    "lng": -103.3692562,
+    "lat": 37.33395632
   },
   "81050": {
     "PO_NAME": "La Junta",
@@ -3209,8 +3209,8 @@
     "POPULATION": 10707,
     "POP_SQMI": 19.63,
     "SQMI": 545.34,
-    "centroid_lon": -103.5246782,
-    "centroid_lat": 37.92146338
+    "lng": -103.5246782,
+    "lat": 37.92146338
   },
   "81052": {
     "PO_NAME": "Lamar",
@@ -3218,8 +3218,8 @@
     "POPULATION": 9545,
     "POP_SQMI": 17.23,
     "SQMI": 554.09,
-    "centroid_lon": -102.606501,
-    "centroid_lat": 37.9444187
+    "lng": -102.606501,
+    "lat": 37.9444187
   },
   "81054": {
     "PO_NAME": "Las Animas",
@@ -3227,8 +3227,8 @@
     "POPULATION": 5288,
     "POP_SQMI": 4.24,
     "SQMI": 1248.51,
-    "centroid_lon": -103.1160413,
-    "centroid_lat": 37.89536112
+    "lng": -103.1160413,
+    "lat": 37.89536112
   },
   "81055": {
     "PO_NAME": "La Veta",
@@ -3236,8 +3236,8 @@
     "POPULATION": 1414,
     "POP_SQMI": 5.12,
     "SQMI": 276.08,
-    "centroid_lon": -105.083662,
-    "centroid_lat": 37.49492609
+    "lng": -105.083662,
+    "lat": 37.49492609
   },
   "81057": {
     "PO_NAME": "Mc Clave",
@@ -3245,8 +3245,8 @@
     "POPULATION": 525,
     "POP_SQMI": 3.42,
     "SQMI": 153.38,
-    "centroid_lon": -102.9246595,
-    "centroid_lat": 38.17942273
+    "lng": -102.9246595,
+    "lat": 38.17942273
   },
   "81058": {
     "PO_NAME": "Manzanola",
@@ -3254,8 +3254,8 @@
     "POPULATION": 959,
     "POP_SQMI": 5.36,
     "SQMI": 178.98,
-    "centroid_lon": -103.9036771,
-    "centroid_lat": 38.01308405
+    "lng": -103.9036771,
+    "lat": 38.01308405
   },
   "81059": {
     "PO_NAME": "Model",
@@ -3263,8 +3263,8 @@
     "POPULATION": 761,
     "POP_SQMI": 0.59,
     "SQMI": 1281.54,
-    "centroid_lon": -104.1426267,
-    "centroid_lat": 37.56066799
+    "lng": -104.1426267,
+    "lat": 37.56066799
   },
   "81062": {
     "PO_NAME": "Olney Springs",
@@ -3272,8 +3272,8 @@
     "POPULATION": 2669,
     "POP_SQMI": 11.51,
     "SQMI": 231.94,
-    "centroid_lon": -103.9724889,
-    "centroid_lat": 38.3125175
+    "lng": -103.9724889,
+    "lat": 38.3125175
   },
   "81063": {
     "PO_NAME": "Ordway",
@@ -3281,8 +3281,8 @@
     "POPULATION": 2846,
     "POP_SQMI": 7.35,
     "SQMI": 387.22,
-    "centroid_lon": -103.7951146,
-    "centroid_lat": 38.43204592
+    "lng": -103.7951146,
+    "lat": 38.43204592
   },
   "81064": {
     "PO_NAME": "Pritchett",
@@ -3290,8 +3290,8 @@
     "POPULATION": 342,
     "POP_SQMI": 0.61,
     "SQMI": 562.91,
-    "centroid_lon": -103.0033791,
-    "centroid_lat": 37.26011345
+    "lng": -103.0033791,
+    "lat": 37.26011345
   },
   "81067": {
     "PO_NAME": "Rocky Ford",
@@ -3299,8 +3299,8 @@
     "POPULATION": 5708,
     "POP_SQMI": 29.45,
     "SQMI": 193.85,
-    "centroid_lon": -103.7410812,
-    "centroid_lat": 37.98194771
+    "lng": -103.7410812,
+    "lat": 37.98194771
   },
   "81069": {
     "PO_NAME": "Rye",
@@ -3308,8 +3308,8 @@
     "POPULATION": 2203,
     "POP_SQMI": 10.74,
     "SQMI": 205.05,
-    "centroid_lon": -104.8548055,
-    "centroid_lat": 37.90625335
+    "lng": -104.8548055,
+    "lat": 37.90625335
   },
   "81071": {
     "PO_NAME": "Sheridan Lake",
@@ -3317,8 +3317,8 @@
     "POPULATION": 326,
     "POP_SQMI": 0.53,
     "SQMI": 619.12,
-    "centroid_lon": -102.2891825,
-    "centroid_lat": 38.43871053
+    "lng": -102.2891825,
+    "lat": 38.43871053
   },
   "81073": {
     "PO_NAME": "Springfield",
@@ -3326,8 +3326,8 @@
     "POPULATION": 1949,
     "POP_SQMI": 2.94,
     "SQMI": 661.9,
-    "centroid_lon": -102.6837801,
-    "centroid_lat": 37.4327849
+    "lng": -102.6837801,
+    "lat": 37.4327849
   },
   "81076": {
     "PO_NAME": "Sugar City",
@@ -3335,8 +3335,8 @@
     "POPULATION": 466,
     "POP_SQMI": 1.37,
     "SQMI": 339.57,
-    "centroid_lon": -103.6114668,
-    "centroid_lat": 38.35986441
+    "lng": -103.6114668,
+    "lat": 38.35986441
   },
   "81077": {
     "PO_NAME": "Swink",
@@ -3344,8 +3344,8 @@
     "POPULATION": 62,
     "POP_SQMI": 182.35,
     "SQMI": 0.34,
-    "centroid_lon": -103.6279688,
-    "centroid_lat": 38.01472108
+    "lng": -103.6279688,
+    "lat": 38.01472108
   },
   "81081": {
     "PO_NAME": "Trinchera",
@@ -3353,8 +3353,8 @@
     "POPULATION": 82,
     "POP_SQMI": 0.31,
     "SQMI": 264.54,
-    "centroid_lon": -104.1540516,
-    "centroid_lat": 37.09194393
+    "lng": -104.1540516,
+    "lat": 37.09194393
   },
   "81082": {
     "PO_NAME": "Trinidad",
@@ -3362,8 +3362,8 @@
     "POPULATION": 11961,
     "POP_SQMI": 14.8,
     "SQMI": 808.24,
-    "centroid_lon": -104.2807033,
-    "centroid_lat": 37.28801774
+    "lng": -104.2807033,
+    "lat": 37.28801774
   },
   "81084": {
     "PO_NAME": "Two Buttes",
@@ -3371,8 +3371,8 @@
     "POPULATION": 122,
     "POP_SQMI": 1.62,
     "SQMI": 75.33,
-    "centroid_lon": -102.3861025,
-    "centroid_lat": 37.52364234
+    "lng": -102.3861025,
+    "lat": 37.52364234
   },
   "81087": {
     "PO_NAME": "Vilas",
@@ -3380,8 +3380,8 @@
     "POPULATION": 136,
     "POP_SQMI": 5.67,
     "SQMI": 23.97,
-    "centroid_lon": -102.43337,
-    "centroid_lat": 37.3420682
+    "lng": -102.43337,
+    "lat": 37.3420682
   },
   "81089": {
     "PO_NAME": "Walsenburg",
@@ -3389,8 +3389,8 @@
     "POPULATION": 4949,
     "POP_SQMI": 5.38,
     "SQMI": 920.59,
-    "centroid_lon": -104.7813381,
-    "centroid_lat": 37.68670684
+    "lng": -104.7813381,
+    "lat": 37.68670684
   },
   "81090": {
     "PO_NAME": "Walsh",
@@ -3398,8 +3398,8 @@
     "POPULATION": 963,
     "POP_SQMI": 1.25,
     "SQMI": 771.27,
-    "centroid_lon": -102.2188897,
-    "centroid_lat": 37.34988602
+    "lng": -102.2188897,
+    "lat": 37.34988602
   },
   "81091": {
     "PO_NAME": "Weston",
@@ -3407,8 +3407,8 @@
     "POPULATION": 944,
     "POP_SQMI": 1.87,
     "SQMI": 505.83,
-    "centroid_lon": -104.9421384,
-    "centroid_lat": 37.14157974
+    "lng": -104.9421384,
+    "lat": 37.14157974
   },
   "81092": {
     "PO_NAME": "Wiley",
@@ -3416,8 +3416,8 @@
     "POPULATION": 828,
     "POP_SQMI": 10.22,
     "SQMI": 81,
-    "centroid_lon": -102.7383657,
-    "centroid_lat": 38.20354529
+    "lng": -102.7383657,
+    "lat": 38.20354529
   },
   "81101": {
     "PO_NAME": "Alamosa",
@@ -3425,8 +3425,8 @@
     "POPULATION": 15951,
     "POP_SQMI": 46.66,
     "SQMI": 341.89,
-    "centroid_lon": -105.8408334,
-    "centroid_lat": 37.46832003
+    "lng": -105.8408334,
+    "lat": 37.46832003
   },
   "81102": {
     "PO_NAME": "Alamosa",
@@ -3434,8 +3434,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.03,
-    "centroid_lon": -105.8795615,
-    "centroid_lat": 37.47102191
+    "lng": -105.8795615,
+    "lat": 37.47102191
   },
   "81120": {
     "PO_NAME": "Antonito",
@@ -3443,8 +3443,8 @@
     "POPULATION": 2624,
     "POP_SQMI": 2.73,
     "SQMI": 961.97,
-    "centroid_lon": -106.2751765,
-    "centroid_lat": 37.17868467
+    "lng": -106.2751765,
+    "lat": 37.17868467
   },
   "81121": {
     "PO_NAME": "Arboles",
@@ -3452,8 +3452,8 @@
     "POPULATION": 61,
     "POP_SQMI": 65.59,
     "SQMI": 0.93,
-    "centroid_lon": -107.4201862,
-    "centroid_lat": 37.0181238
+    "lng": -107.4201862,
+    "lat": 37.0181238
   },
   "81122": {
     "PO_NAME": "Bayfield",
@@ -3461,8 +3461,8 @@
     "POPULATION": 9502,
     "POP_SQMI": 19.21,
     "SQMI": 494.71,
-    "centroid_lon": -107.5193822,
-    "centroid_lat": 37.36935883
+    "lng": -107.5193822,
+    "lat": 37.36935883
   },
   "81123": {
     "PO_NAME": "Blanca",
@@ -3470,8 +3470,8 @@
     "POPULATION": 863,
     "POP_SQMI": 4.78,
     "SQMI": 180.5,
-    "centroid_lon": -105.5641128,
-    "centroid_lat": 37.38773834
+    "lng": -105.5641128,
+    "lat": 37.38773834
   },
   "81124": {
     "PO_NAME": "Capulin",
@@ -3479,8 +3479,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 1.61,
-    "centroid_lon": -106.1080838,
-    "centroid_lat": 37.29135017
+    "lng": -106.1080838,
+    "lat": 37.29135017
   },
   "81125": {
     "PO_NAME": "Center",
@@ -3488,8 +3488,8 @@
     "POPULATION": 4027,
     "POP_SQMI": 7.68,
     "SQMI": 524.14,
-    "centroid_lon": -106.0641982,
-    "centroid_lat": 37.8201863
+    "lng": -106.0641982,
+    "lat": 37.8201863
   },
   "81126": {
     "PO_NAME": "Chama",
@@ -3497,8 +3497,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 1.73,
-    "centroid_lon": -105.371632,
-    "centroid_lat": 37.16436995
+    "lng": -105.371632,
+    "lat": 37.16436995
   },
   "81129": {
     "PO_NAME": "Conejos",
@@ -3506,8 +3506,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 0.46,
-    "centroid_lon": -106.0161075,
-    "centroid_lat": 37.08727678
+    "lng": -106.0161075,
+    "lat": 37.08727678
   },
   "81130": {
     "PO_NAME": "Creede",
@@ -3515,8 +3515,8 @@
     "POPULATION": 749,
     "POP_SQMI": 0.84,
     "SQMI": 891.25,
-    "centroid_lon": -106.9557997,
-    "centroid_lat": 37.66922006
+    "lng": -106.9557997,
+    "lat": 37.66922006
   },
   "81131": {
     "PO_NAME": "Crestone",
@@ -3524,8 +3524,8 @@
     "POPULATION": 1080,
     "POP_SQMI": 8.36,
     "SQMI": 129.22,
-    "centroid_lon": -105.5777836,
-    "centroid_lat": 37.89592196
+    "lng": -105.5777836,
+    "lat": 37.89592196
   },
   "81132": {
     "PO_NAME": "Del Norte",
@@ -3533,8 +3533,8 @@
     "POPULATION": 3551,
     "POP_SQMI": 6.71,
     "SQMI": 529.04,
-    "centroid_lon": -106.431373,
-    "centroid_lat": 37.61051116
+    "lng": -106.431373,
+    "lat": 37.61051116
   },
   "81133": {
     "PO_NAME": "Fort Garland",
@@ -3542,8 +3542,8 @@
     "POPULATION": 1067,
     "POP_SQMI": 2.53,
     "SQMI": 421.24,
-    "centroid_lon": -105.3184469,
-    "centroid_lat": 37.44149033
+    "lng": -105.3184469,
+    "lat": 37.44149033
   },
   "81136": {
     "PO_NAME": "Hooper",
@@ -3551,8 +3551,8 @@
     "POPULATION": 254,
     "POP_SQMI": 3.27,
     "SQMI": 77.64,
-    "centroid_lon": -105.818003,
-    "centroid_lat": 37.71608504
+    "lng": -105.818003,
+    "lat": 37.71608504
   },
   "81137": {
     "PO_NAME": "Ignacio",
@@ -3560,8 +3560,8 @@
     "POPULATION": 5822,
     "POP_SQMI": 25.5,
     "SQMI": 228.28,
-    "centroid_lon": -107.6295549,
-    "centroid_lat": 37.08166715
+    "lng": -107.6295549,
+    "lat": 37.08166715
   },
   "81138": {
     "PO_NAME": "Jaroso",
@@ -3569,8 +3569,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 1.04,
-    "centroid_lon": -105.6186365,
-    "centroid_lat": 37.00330542
+    "lng": -105.6186365,
+    "lat": 37.00330542
   },
   "81140": {
     "PO_NAME": "La Jara",
@@ -3578,8 +3578,8 @@
     "POPULATION": 2852,
     "POP_SQMI": 19.46,
     "SQMI": 146.52,
-    "centroid_lon": -106.0471121,
-    "centroid_lat": 37.29946881
+    "lng": -106.0471121,
+    "lat": 37.29946881
   },
   "81141": {
     "PO_NAME": "Manassa",
@@ -3587,8 +3587,8 @@
     "POPULATION": 1490,
     "POP_SQMI": 2292.31,
     "SQMI": 0.65,
-    "centroid_lon": -105.9357788,
-    "centroid_lat": 37.17228398
+    "lng": -105.9357788,
+    "lat": 37.17228398
   },
   "81143": {
     "PO_NAME": "Moffat",
@@ -3596,8 +3596,8 @@
     "POPULATION": 971,
     "POP_SQMI": 1.93,
     "SQMI": 504.34,
-    "centroid_lon": -105.8661229,
-    "centroid_lat": 38.06758981
+    "lng": -105.8661229,
+    "lat": 38.06758981
   },
   "81144": {
     "PO_NAME": "Monte Vista",
@@ -3605,8 +3605,8 @@
     "POPULATION": 7866,
     "POP_SQMI": 28.91,
     "SQMI": 272.11,
-    "centroid_lon": -106.1553559,
-    "centroid_lat": 37.54512565
+    "lng": -106.1553559,
+    "lat": 37.54512565
   },
   "81146": {
     "PO_NAME": "Mosca",
@@ -3614,8 +3614,8 @@
     "POPULATION": 737,
     "POP_SQMI": 2.47,
     "SQMI": 298.85,
-    "centroid_lon": -105.7115599,
-    "centroid_lat": 37.63851424
+    "lng": -105.7115599,
+    "lat": 37.63851424
   },
   "81147": {
     "PO_NAME": "Pagosa Springs",
@@ -3623,8 +3623,8 @@
     "POPULATION": 14556,
     "POP_SQMI": 12.23,
     "SQMI": 1190.1,
-    "centroid_lon": -106.9983512,
-    "centroid_lat": 37.18210564
+    "lng": -106.9983512,
+    "lat": 37.18210564
   },
   "81149": {
     "PO_NAME": "Saguache",
@@ -3632,8 +3632,8 @@
     "POPULATION": 955,
     "POP_SQMI": 0.57,
     "SQMI": 1676.01,
-    "centroid_lon": -106.5464058,
-    "centroid_lat": 38.14766663
+    "lng": -106.5464058,
+    "lat": 38.14766663
   },
   "81151": {
     "PO_NAME": "Sanford",
@@ -3641,8 +3641,8 @@
     "POPULATION": 2301,
     "POP_SQMI": 7.03,
     "SQMI": 327.49,
-    "centroid_lon": -105.7282854,
-    "centroid_lat": 37.23069106
+    "lng": -105.7282854,
+    "lat": 37.23069106
   },
   "81152": {
     "PO_NAME": "San Luis",
@@ -3650,8 +3650,8 @@
     "POPULATION": 1366,
     "POP_SQMI": 2.94,
     "SQMI": 464.39,
-    "centroid_lon": -105.4183194,
-    "centroid_lat": 37.10327691
+    "lng": -105.4183194,
+    "lat": 37.10327691
   },
   "81154": {
     "PO_NAME": "South Fork",
@@ -3659,8 +3659,8 @@
     "POPULATION": 1183,
     "POP_SQMI": 4.48,
     "SQMI": 264.34,
-    "centroid_lon": -106.6824515,
-    "centroid_lat": 37.68043012
+    "lng": -106.6824515,
+    "lat": 37.68043012
   },
   "81155": {
     "PO_NAME": "Villa Grove",
@@ -3668,8 +3668,8 @@
     "POPULATION": 267,
     "POP_SQMI": 1.01,
     "SQMI": 264.29,
-    "centroid_lon": -106.0750744,
-    "centroid_lat": 38.31566773
+    "lng": -106.0750744,
+    "lat": 38.31566773
   },
   "81201": {
     "PO_NAME": "Salida",
@@ -3677,8 +3677,8 @@
     "POPULATION": 9965,
     "POP_SQMI": 23.83,
     "SQMI": 418.19,
-    "centroid_lon": -106.0679498,
-    "centroid_lat": 38.55176837
+    "lng": -106.0679498,
+    "lat": 38.55176837
   },
   "81210": {
     "PO_NAME": "Almont",
@@ -3686,8 +3686,8 @@
     "POPULATION": 206,
     "POP_SQMI": 0.38,
     "SQMI": 546.91,
-    "centroid_lon": -106.6166318,
-    "centroid_lat": 38.801861
+    "lng": -106.6166318,
+    "lat": 38.801861
   },
   "81211": {
     "PO_NAME": "Buena Vista",
@@ -3695,8 +3695,8 @@
     "POPULATION": 8297,
     "POP_SQMI": 15.25,
     "SQMI": 544.24,
-    "centroid_lon": -106.2332457,
-    "centroid_lat": 38.87423053
+    "lng": -106.2332457,
+    "lat": 38.87423053
   },
   "81212": {
     "PO_NAME": "Canon City",
@@ -3704,8 +3704,8 @@
     "POPULATION": 31122,
     "POP_SQMI": 61.76,
     "SQMI": 503.94,
-    "centroid_lon": -105.3448422,
-    "centroid_lat": 38.53774639
+    "lng": -105.3448422,
+    "lat": 38.53774639
   },
   "81220": {
     "PO_NAME": "Cimarron",
@@ -3713,8 +3713,8 @@
     "POPULATION": 159,
     "POP_SQMI": 0.94,
     "SQMI": 169.13,
-    "centroid_lon": -107.5083707,
-    "centroid_lat": 38.37208133
+    "lng": -107.5083707,
+    "lat": 38.37208133
   },
   "81223": {
     "PO_NAME": "Cotopaxi",
@@ -3722,8 +3722,8 @@
     "POPULATION": 2188,
     "POP_SQMI": 6.41,
     "SQMI": 341.56,
-    "centroid_lon": -105.5458161,
-    "centroid_lat": 38.4063588
+    "lng": -105.5458161,
+    "lat": 38.4063588
   },
   "81224": {
     "PO_NAME": "Crested Butte",
@@ -3731,8 +3731,8 @@
     "POPULATION": 4036,
     "POP_SQMI": 18.69,
     "SQMI": 215.91,
-    "centroid_lon": -106.889554,
-    "centroid_lat": 38.89681815
+    "lng": -106.889554,
+    "lat": 38.89681815
   },
   "81225": {
     "PO_NAME": "Crested Butte",
@@ -3740,8 +3740,8 @@
     "POPULATION": 868,
     "POP_SQMI": 1112.82,
     "SQMI": 0.78,
-    "centroid_lon": -106.9670748,
-    "centroid_lat": 38.90881863
+    "lng": -106.9670748,
+    "lat": 38.90881863
   },
   "81226": {
     "PO_NAME": "Florence",
@@ -3749,8 +3749,8 @@
     "POPULATION": 9851,
     "POP_SQMI": 103.83,
     "SQMI": 94.88,
-    "centroid_lon": -105.1509045,
-    "centroid_lat": 38.32327995
+    "lng": -105.1509045,
+    "lat": 38.32327995
   },
   "81228": {
     "PO_NAME": "Granite",
@@ -3758,8 +3758,8 @@
     "POPULATION": 356,
     "POP_SQMI": 5.46,
     "SQMI": 65.24,
-    "centroid_lon": -106.2665615,
-    "centroid_lat": 39.09154347
+    "lng": -106.2665615,
+    "lat": 39.09154347
   },
   "81230": {
     "PO_NAME": "Gunnison",
@@ -3767,8 +3767,8 @@
     "POPULATION": 11395,
     "POP_SQMI": 7.91,
     "SQMI": 1440.87,
-    "centroid_lon": -107.0612394,
-    "centroid_lat": 38.51215676
+    "lng": -107.0612394,
+    "lat": 38.51215676
   },
   "81231": {
     "PO_NAME": "Gunnison",
@@ -3776,8 +3776,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 1.38,
-    "centroid_lon": -106.90457,
-    "centroid_lat": 38.55220205
+    "lng": -106.90457,
+    "lat": 38.55220205
   },
   "81233": {
     "PO_NAME": "Howard",
@@ -3785,8 +3785,8 @@
     "POPULATION": 979,
     "POP_SQMI": 3.41,
     "SQMI": 287.3,
-    "centroid_lon": -105.7942608,
-    "centroid_lat": 38.46765999
+    "lng": -105.7942608,
+    "lat": 38.46765999
   },
   "81235": {
     "PO_NAME": "Lake City",
@@ -3794,8 +3794,8 @@
     "POPULATION": 699,
     "POP_SQMI": 0.68,
     "SQMI": 1026.63,
-    "centroid_lon": -107.3104634,
-    "centroid_lat": 37.83336132
+    "lng": -107.3104634,
+    "lat": 37.83336132
   },
   "81236": {
     "PO_NAME": "Nathrop",
@@ -3803,8 +3803,8 @@
     "POPULATION": 1510,
     "POP_SQMI": 13,
     "SQMI": 116.19,
-    "centroid_lon": -106.2265208,
-    "centroid_lat": 38.68561834
+    "lng": -106.2265208,
+    "lat": 38.68561834
   },
   "81237": {
     "PO_NAME": "Ohio City",
@@ -3812,8 +3812,8 @@
     "POPULATION": 72,
     "POP_SQMI": 4.08,
     "SQMI": 17.64,
-    "centroid_lon": -106.5933378,
-    "centroid_lat": 38.61379883
+    "lng": -106.5933378,
+    "lat": 38.61379883
   },
   "81239": {
     "PO_NAME": "Parlin",
@@ -3821,8 +3821,8 @@
     "POPULATION": 61,
     "POP_SQMI": 1.32,
     "SQMI": 46.32,
-    "centroid_lon": -106.6225364,
-    "centroid_lat": 38.53776209
+    "lng": -106.6225364,
+    "lat": 38.53776209
   },
   "81240": {
     "PO_NAME": "Penrose",
@@ -3830,8 +3830,8 @@
     "POPULATION": 4544,
     "POP_SQMI": 20.38,
     "SQMI": 222.95,
-    "centroid_lon": -105.0212123,
-    "centroid_lat": 38.46958873
+    "lng": -105.0212123,
+    "lat": 38.46958873
   },
   "81241": {
     "PO_NAME": "Pitkin",
@@ -3839,8 +3839,8 @@
     "POPULATION": 119,
     "POP_SQMI": 476,
     "SQMI": 0.25,
-    "centroid_lon": -106.5162879,
-    "centroid_lat": 38.60876868
+    "lng": -106.5162879,
+    "lat": 38.60876868
   },
   "81242": {
     "PO_NAME": "Poncha Springs",
@@ -3848,8 +3848,8 @@
     "POPULATION": 746,
     "POP_SQMI": 738.61,
     "SQMI": 1.01,
-    "centroid_lon": -106.070819,
-    "centroid_lat": 38.51069291
+    "lng": -106.070819,
+    "lat": 38.51069291
   },
   "81243": {
     "PO_NAME": "Powderhorn",
@@ -3857,8 +3857,8 @@
     "POPULATION": 250,
     "POP_SQMI": 1.23,
     "SQMI": 202.9,
-    "centroid_lon": -107.130469,
-    "centroid_lat": 38.24975574
+    "lng": -107.130469,
+    "lat": 38.24975574
   },
   "81244": {
     "PO_NAME": "Rockvale",
@@ -3866,8 +3866,8 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 1.8,
-    "centroid_lon": -105.1653891,
-    "centroid_lat": 38.36337121
+    "lng": -105.1653891,
+    "lat": 38.36337121
   },
   "81251": {
     "PO_NAME": "Twin Lakes",
@@ -3875,8 +3875,8 @@
     "POPULATION": 94,
     "POP_SQMI": 0.73,
     "SQMI": 129.08,
-    "centroid_lon": -106.4498842,
-    "centroid_lat": 39.14544365
+    "lng": -106.4498842,
+    "lat": 39.14544365
   },
   "81252": {
     "PO_NAME": "Westcliffe",
@@ -3884,8 +3884,8 @@
     "POPULATION": 4518,
     "POP_SQMI": 8.4,
     "SQMI": 537.54,
-    "centroid_lon": -105.4480891,
-    "centroid_lat": 38.11276194
+    "lng": -105.4480891,
+    "lat": 38.11276194
   },
   "81253": {
     "PO_NAME": "Wetmore",
@@ -3893,8 +3893,8 @@
     "POPULATION": 537,
     "POP_SQMI": 2.45,
     "SQMI": 219.07,
-    "centroid_lon": -105.1608676,
-    "centroid_lat": 38.08126537
+    "lng": -105.1608676,
+    "lat": 38.08126537
   },
   "81301": {
     "PO_NAME": "Durango",
@@ -3902,8 +3902,8 @@
     "POPULATION": 32265,
     "POP_SQMI": 63.2,
     "SQMI": 510.56,
-    "centroid_lon": -107.8319394,
-    "centroid_lat": 37.44914525
+    "lng": -107.8319394,
+    "lat": 37.44914525
   },
   "81303": {
     "PO_NAME": "Durango",
@@ -3911,8 +3911,8 @@
     "POPULATION": 8546,
     "POP_SQMI": 33.23,
     "SQMI": 257.21,
-    "centroid_lon": -107.9187525,
-    "centroid_lat": 37.16611696
+    "lng": -107.9187525,
+    "lat": 37.16611696
   },
   "81320": {
     "PO_NAME": "Cahone",
@@ -3920,8 +3920,8 @@
     "POPULATION": 302,
     "POP_SQMI": 0.36,
     "SQMI": 834.15,
-    "centroid_lon": -108.3984642,
-    "centroid_lat": 37.75751042
+    "lng": -108.3984642,
+    "lat": 37.75751042
   },
   "81321": {
     "PO_NAME": "Cortez",
@@ -3929,8 +3929,8 @@
     "POPULATION": 14310,
     "POP_SQMI": 47.67,
     "SQMI": 300.21,
-    "centroid_lon": -108.7420692,
-    "centroid_lat": 37.3470491
+    "lng": -108.7420692,
+    "lat": 37.3470491
   },
   "81323": {
     "PO_NAME": "Dolores",
@@ -3938,8 +3938,8 @@
     "POPULATION": 4548,
     "POP_SQMI": 12.27,
     "SQMI": 370.76,
-    "centroid_lon": -108.3498727,
-    "centroid_lat": 37.54437822
+    "lng": -108.3498727,
+    "lat": 37.54437822
   },
   "81324": {
     "PO_NAME": "Dove Creek",
@@ -3947,8 +3947,8 @@
     "POPULATION": 1557,
     "POP_SQMI": 6.69,
     "SQMI": 232.85,
-    "centroid_lon": -108.9449424,
-    "centroid_lat": 37.73072353
+    "lng": -108.9449424,
+    "lat": 37.73072353
   },
   "81325": {
     "PO_NAME": "Egnar",
@@ -3956,8 +3956,8 @@
     "POPULATION": 115,
     "POP_SQMI": 0.21,
     "SQMI": 544.52,
-    "centroid_lon": -108.7589017,
-    "centroid_lat": 38.00603663
+    "lng": -108.7589017,
+    "lat": 38.00603663
   },
   "81326": {
     "PO_NAME": "Hesperus",
@@ -3965,8 +3965,8 @@
     "POPULATION": 2734,
     "POP_SQMI": 8.22,
     "SQMI": 332.75,
-    "centroid_lon": -108.145398,
-    "centroid_lat": 37.14431456
+    "lng": -108.145398,
+    "lat": 37.14431456
   },
   "81327": {
     "PO_NAME": "Lewis",
@@ -3974,8 +3974,8 @@
     "POPULATION": 764,
     "POP_SQMI": 17.48,
     "SQMI": 43.71,
-    "centroid_lon": -108.6352522,
-    "centroid_lat": 37.52149812
+    "lng": -108.6352522,
+    "lat": 37.52149812
   },
   "81328": {
     "PO_NAME": "Mancos",
@@ -3983,8 +3983,8 @@
     "POPULATION": 4684,
     "POP_SQMI": 11.19,
     "SQMI": 418.43,
-    "centroid_lon": -108.2971544,
-    "centroid_lat": 37.35320814
+    "lng": -108.2971544,
+    "lat": 37.35320814
   },
   "81331": {
     "PO_NAME": "Pleasant View",
@@ -3992,8 +3992,8 @@
     "POPULATION": 348,
     "POP_SQMI": 1.59,
     "SQMI": 219.16,
-    "centroid_lon": -108.8775749,
-    "centroid_lat": 37.5193645
+    "lng": -108.8775749,
+    "lat": 37.5193645
   },
   "81332": {
     "PO_NAME": "Rico",
@@ -4001,8 +4001,8 @@
     "POPULATION": 292,
     "POP_SQMI": 275.47,
     "SQMI": 1.06,
-    "centroid_lon": -108.029205,
-    "centroid_lat": 37.6881796
+    "lng": -108.029205,
+    "lat": 37.6881796
   },
   "81334": {
     "PO_NAME": "Towaoc",
@@ -4010,8 +4010,8 @@
     "POPULATION": 1390,
     "POP_SQMI": 2.02,
     "SQMI": 689.03,
-    "centroid_lon": -108.7071737,
-    "centroid_lat": 37.13168576
+    "lng": -108.7071737,
+    "lat": 37.13168576
   },
   "81335": {
     "PO_NAME": "Yellow Jacket",
@@ -4019,8 +4019,8 @@
     "POPULATION": 188,
     "POP_SQMI": 3.51,
     "SQMI": 53.49,
-    "centroid_lon": -108.7822505,
-    "centroid_lat": 37.49511988
+    "lng": -108.7822505,
+    "lat": 37.49511988
   },
   "81401": {
     "PO_NAME": "Montrose",
@@ -4028,8 +4028,8 @@
     "POPULATION": 23952,
     "POP_SQMI": 116.62,
     "SQMI": 205.39,
-    "centroid_lon": -107.7910311,
-    "centroid_lat": 38.49832416
+    "lng": -107.7910311,
+    "lat": 38.49832416
   },
   "81403": {
     "PO_NAME": "Montrose",
@@ -4037,8 +4037,8 @@
     "POPULATION": 12261,
     "POP_SQMI": 28.46,
     "SQMI": 430.82,
-    "centroid_lon": -107.9461054,
-    "centroid_lat": 38.36091298
+    "lng": -107.9461054,
+    "lat": 38.36091298
   },
   "81410": {
     "PO_NAME": "Austin",
@@ -4046,8 +4046,8 @@
     "POPULATION": 1712,
     "POP_SQMI": 65.69,
     "SQMI": 26.06,
-    "centroid_lon": -107.9410033,
-    "centroid_lat": 38.79564762
+    "lng": -107.9410033,
+    "lat": 38.79564762
   },
   "81411": {
     "PO_NAME": "Bedrock",
@@ -4055,8 +4055,8 @@
     "POPULATION": 91,
     "POP_SQMI": 0.29,
     "SQMI": 309.18,
-    "centroid_lon": -108.9197126,
-    "centroid_lat": 38.30445749
+    "lng": -108.9197126,
+    "lat": 38.30445749
   },
   "81413": {
     "PO_NAME": "Cedaredge",
@@ -4064,8 +4064,8 @@
     "POPULATION": 4856,
     "POP_SQMI": 25.14,
     "SQMI": 193.19,
-    "centroid_lon": -107.8883767,
-    "centroid_lat": 38.97714621
+    "lng": -107.8883767,
+    "lat": 38.97714621
   },
   "81415": {
     "PO_NAME": "Crawford",
@@ -4073,8 +4073,8 @@
     "POPULATION": 1722,
     "POP_SQMI": 5.79,
     "SQMI": 297.4,
-    "centroid_lon": -107.6383426,
-    "centroid_lat": 38.6422836
+    "lng": -107.6383426,
+    "lat": 38.6422836
   },
   "81416": {
     "PO_NAME": "Delta",
@@ -4082,8 +4082,8 @@
     "POPULATION": 14074,
     "POP_SQMI": 36.61,
     "SQMI": 384.41,
-    "centroid_lon": -108.1510204,
-    "centroid_lat": 38.7432641
+    "lng": -108.1510204,
+    "lat": 38.7432641
   },
   "81418": {
     "PO_NAME": "Eckert",
@@ -4091,8 +4091,8 @@
     "POPULATION": 1898,
     "POP_SQMI": 29.39,
     "SQMI": 64.57,
-    "centroid_lon": -108.0512004,
-    "centroid_lat": 38.89375396
+    "lng": -108.0512004,
+    "lat": 38.89375396
   },
   "81419": {
     "PO_NAME": "Hotchkiss",
@@ -4100,8 +4100,8 @@
     "POPULATION": 4541,
     "POP_SQMI": 29.37,
     "SQMI": 154.59,
-    "centroid_lon": -107.7581798,
-    "centroid_lat": 38.83420924
+    "lng": -107.7581798,
+    "lat": 38.83420924
   },
   "81422": {
     "PO_NAME": "Naturita",
@@ -4109,8 +4109,8 @@
     "POPULATION": 699,
     "POP_SQMI": 2.59,
     "SQMI": 269.64,
-    "centroid_lon": -108.7009745,
-    "centroid_lat": 38.34279792
+    "lng": -108.7009745,
+    "lat": 38.34279792
   },
   "81423": {
     "PO_NAME": "Norwood",
@@ -4118,8 +4118,8 @@
     "POPULATION": 1529,
     "POP_SQMI": 3.96,
     "SQMI": 385.92,
-    "centroid_lon": -108.3172316,
-    "centroid_lat": 38.04241498
+    "lng": -108.3172316,
+    "lat": 38.04241498
   },
   "81424": {
     "PO_NAME": "Nucla",
@@ -4127,8 +4127,8 @@
     "POPULATION": 1319,
     "POP_SQMI": 5.01,
     "SQMI": 263.3,
-    "centroid_lon": -108.4595894,
-    "centroid_lat": 38.33923475
+    "lng": -108.4595894,
+    "lat": 38.33923475
   },
   "81425": {
     "PO_NAME": "Olathe",
@@ -4136,8 +4136,8 @@
     "POPULATION": 6018,
     "POP_SQMI": 17.39,
     "SQMI": 346.14,
-    "centroid_lon": -108.2144113,
-    "centroid_lat": 38.52678714
+    "lng": -108.2144113,
+    "lat": 38.52678714
   },
   "81426": {
     "PO_NAME": "Ophir",
@@ -4145,8 +4145,8 @@
     "POPULATION": 425,
     "POP_SQMI": 5.78,
     "SQMI": 73.54,
-    "centroid_lon": -107.8948424,
-    "centroid_lat": 37.85702653
+    "lng": -107.8948424,
+    "lat": 37.85702653
   },
   "81427": {
     "PO_NAME": "Ouray",
@@ -4154,8 +4154,8 @@
     "POPULATION": 1078,
     "POP_SQMI": 32.3,
     "SQMI": 33.37,
-    "centroid_lon": -107.6840254,
-    "centroid_lat": 37.95249817
+    "lng": -107.6840254,
+    "lat": 37.95249817
   },
   "81428": {
     "PO_NAME": "Paonia",
@@ -4163,8 +4163,8 @@
     "POPULATION": 3784,
     "POP_SQMI": 15.02,
     "SQMI": 251.98,
-    "centroid_lon": -107.5922213,
-    "centroid_lat": 38.98896556
+    "lng": -107.5922213,
+    "lat": 38.98896556
   },
   "81429": {
     "PO_NAME": "Paradox",
@@ -4172,8 +4172,8 @@
     "POPULATION": 164,
     "POP_SQMI": 8.13,
     "SQMI": 20.16,
-    "centroid_lon": -108.9692089,
-    "centroid_lat": 38.37269602
+    "lng": -108.9692089,
+    "lat": 38.37269602
   },
   "81430": {
     "PO_NAME": "Placerville",
@@ -4181,8 +4181,8 @@
     "POPULATION": 843,
     "POP_SQMI": 5.46,
     "SQMI": 154.44,
-    "centroid_lon": -108.0270115,
-    "centroid_lat": 37.96939682
+    "lng": -108.0270115,
+    "lat": 37.96939682
   },
   "81431": {
     "PO_NAME": "Redvale",
@@ -4190,8 +4190,8 @@
     "POPULATION": 671,
     "POP_SQMI": 2.95,
     "SQMI": 227.58,
-    "centroid_lon": -108.2500883,
-    "centroid_lat": 38.21406619
+    "lng": -108.2500883,
+    "lat": 38.21406619
   },
   "81432": {
     "PO_NAME": "Ridgway",
@@ -4199,8 +4199,8 @@
     "POPULATION": 3291,
     "POP_SQMI": 8.01,
     "SQMI": 410.67,
-    "centroid_lon": -107.7747764,
-    "centroid_lat": 38.11336331
+    "lng": -107.7747764,
+    "lat": 38.11336331
   },
   "81433": {
     "PO_NAME": "Silverton",
@@ -4208,8 +4208,8 @@
     "POPULATION": 682,
     "POP_SQMI": 1.78,
     "SQMI": 383.93,
-    "centroid_lon": -107.6746083,
-    "centroid_lat": 37.76523812
+    "lng": -107.6746083,
+    "lat": 37.76523812
   },
   "81434": {
     "PO_NAME": "Somerset",
@@ -4217,8 +4217,8 @@
     "POPULATION": 174,
     "POP_SQMI": 0.3,
     "SQMI": 572.47,
-    "centroid_lon": -107.3437557,
-    "centroid_lat": 38.93779236
+    "lng": -107.3437557,
+    "lat": 38.93779236
   },
   "81435": {
     "PO_NAME": "Telluride",
@@ -4226,8 +4226,8 @@
     "POPULATION": 5314,
     "POP_SQMI": 70.43,
     "SQMI": 75.45,
-    "centroid_lon": -107.8481215,
-    "centroid_lat": 37.93918647
+    "lng": -107.8481215,
+    "lat": 37.93918647
   },
   "81501": {
     "PO_NAME": "Grand Junction",
@@ -4235,8 +4235,8 @@
     "POPULATION": 26299,
     "POP_SQMI": 2951.63,
     "SQMI": 8.91,
-    "centroid_lon": -108.5460388,
-    "centroid_lat": 39.07213001
+    "lng": -108.5460388,
+    "lat": 39.07213001
   },
   "81503": {
     "PO_NAME": "Grand Junction",
@@ -4244,8 +4244,8 @@
     "POPULATION": 17466,
     "POP_SQMI": 1062.41,
     "SQMI": 16.44,
-    "centroid_lon": -108.4883249,
-    "centroid_lat": 39.0362473
+    "lng": -108.4883249,
+    "lat": 39.0362473
   },
   "81504": {
     "PO_NAME": "Grand Junction",
@@ -4253,8 +4253,8 @@
     "POPULATION": 31716,
     "POP_SQMI": 1285.09,
     "SQMI": 24.68,
-    "centroid_lon": -108.469954,
-    "centroid_lat": 39.1056955
+    "lng": -108.469954,
+    "lat": 39.1056955
   },
   "81505": {
     "PO_NAME": "Grand Junction",
@@ -4262,8 +4262,8 @@
     "POPULATION": 11433,
     "POP_SQMI": 156.92,
     "SQMI": 72.86,
-    "centroid_lon": -108.6003851,
-    "centroid_lat": 39.18570997
+    "lng": -108.6003851,
+    "lat": 39.18570997
   },
   "81506": {
     "PO_NAME": "Grand Junction",
@@ -4271,8 +4271,8 @@
     "POPULATION": 11966,
     "POP_SQMI": 325.87,
     "SQMI": 36.72,
-    "centroid_lon": -108.5233949,
-    "centroid_lat": 39.15597872
+    "lng": -108.5233949,
+    "lat": 39.15597872
   },
   "81507": {
     "PO_NAME": "Grand Junction",
@@ -4280,8 +4280,8 @@
     "POPULATION": 16351,
     "POP_SQMI": 266.39,
     "SQMI": 61.38,
-    "centroid_lon": -108.6573329,
-    "centroid_lat": 39.05299961
+    "lng": -108.6573329,
+    "lat": 39.05299961
   },
   "81520": {
     "PO_NAME": "Clifton",
@@ -4289,8 +4289,8 @@
     "POPULATION": 13555,
     "POP_SQMI": 1543.85,
     "SQMI": 8.78,
-    "centroid_lon": -108.4319637,
-    "centroid_lat": 39.09083743
+    "lng": -108.4319637,
+    "lat": 39.09083743
   },
   "81521": {
     "PO_NAME": "Fruita",
@@ -4298,8 +4298,8 @@
     "POPULATION": 17469,
     "POP_SQMI": 137.29,
     "SQMI": 127.24,
-    "centroid_lon": -108.6871581,
-    "centroid_lat": 39.25337188
+    "lng": -108.6871581,
+    "lat": 39.25337188
   },
   "81522": {
     "PO_NAME": "Gateway",
@@ -4307,8 +4307,8 @@
     "POPULATION": 393,
     "POP_SQMI": 0.43,
     "SQMI": 922.86,
-    "centroid_lon": -108.7039216,
-    "centroid_lat": 38.69344526
+    "lng": -108.7039216,
+    "lat": 38.69344526
   },
   "81523": {
     "PO_NAME": "Glade Park",
@@ -4316,8 +4316,8 @@
     "POPULATION": 998,
     "POP_SQMI": 2.39,
     "SQMI": 418.01,
-    "centroid_lon": -108.880383,
-    "centroid_lat": 38.98793287
+    "lng": -108.880383,
+    "lat": 38.98793287
   },
   "81524": {
     "PO_NAME": "Loma",
@@ -4325,8 +4325,8 @@
     "POPULATION": 2573,
     "POP_SQMI": 39.05,
     "SQMI": 65.89,
-    "centroid_lon": -108.7956954,
-    "centroid_lat": 39.26588254
+    "lng": -108.7956954,
+    "lat": 39.26588254
   },
   "81525": {
     "PO_NAME": "Mack",
@@ -4334,8 +4334,8 @@
     "POPULATION": 946,
     "POP_SQMI": 5.96,
     "SQMI": 158.75,
-    "centroid_lon": -108.9501429,
-    "centroid_lat": 39.26565648
+    "lng": -108.9501429,
+    "lat": 39.26565648
   },
   "81526": {
     "PO_NAME": "Palisade",
@@ -4343,8 +4343,8 @@
     "POPULATION": 5847,
     "POP_SQMI": 181.3,
     "SQMI": 32.25,
-    "centroid_lon": -108.3544036,
-    "centroid_lat": 39.09204414
+    "lng": -108.3544036,
+    "lat": 39.09204414
   },
   "81527": {
     "PO_NAME": "Whitewater",
@@ -4352,8 +4352,8 @@
     "POPULATION": 2076,
     "POP_SQMI": 8.72,
     "SQMI": 238.16,
-    "centroid_lon": -108.4077363,
-    "centroid_lat": 38.92177697
+    "lng": -108.4077363,
+    "lat": 38.92177697
   },
   "81601": {
     "PO_NAME": "Glenwood Springs",
@@ -4361,8 +4361,8 @@
     "POPULATION": 16739,
     "POP_SQMI": 43.21,
     "SQMI": 387.35,
-    "centroid_lon": -107.293787,
-    "centroid_lat": 39.60570075
+    "lng": -107.293787,
+    "lat": 39.60570075
   },
   "81610": {
     "PO_NAME": "Dinosaur",
@@ -4370,8 +4370,8 @@
     "POPULATION": 502,
     "POP_SQMI": 1.06,
     "SQMI": 474.24,
-    "centroid_lon": -108.8195358,
-    "centroid_lat": 40.36177156
+    "lng": -108.8195358,
+    "lat": 40.36177156
   },
   "81611": {
     "PO_NAME": "Aspen",
@@ -4379,8 +4379,8 @@
     "POPULATION": 9743,
     "POP_SQMI": 32.11,
     "SQMI": 303.46,
-    "centroid_lon": -106.7914124,
-    "centroid_lat": 39.11704947
+    "lng": -106.7914124,
+    "lat": 39.11704947
   },
   "81612": {
     "PO_NAME": "Aspen",
@@ -4388,8 +4388,8 @@
     "POPULATION": 109,
     "POP_SQMI": 87.9,
     "SQMI": 1.24,
-    "centroid_lon": -106.8227622,
-    "centroid_lat": 39.20666924
+    "lng": -106.8227622,
+    "lat": 39.20666924
   },
   "81615": {
     "PO_NAME": "Snowmass Village",
@@ -4397,8 +4397,8 @@
     "POPULATION": 3326,
     "POP_SQMI": 136.26,
     "SQMI": 24.41,
-    "centroid_lon": -106.9420859,
-    "centroid_lat": 39.21406759
+    "lng": -106.9420859,
+    "lat": 39.21406759
   },
   "81620": {
     "PO_NAME": "Avon",
@@ -4406,8 +4406,8 @@
     "POPULATION": 10445,
     "POP_SQMI": 790.69,
     "SQMI": 13.21,
-    "centroid_lon": -106.5111113,
-    "centroid_lat": 39.63276236
+    "lng": -106.5111113,
+    "lat": 39.63276236
   },
   "81621": {
     "PO_NAME": "Basalt",
@@ -4415,8 +4415,8 @@
     "POPULATION": 6985,
     "POP_SQMI": 17.72,
     "SQMI": 394.12,
-    "centroid_lon": -106.8355555,
-    "centroid_lat": 39.33922314
+    "lng": -106.8355555,
+    "lat": 39.33922314
   },
   "81623": {
     "PO_NAME": "Carbondale",
@@ -4424,8 +4424,8 @@
     "POPULATION": 16607,
     "POP_SQMI": 34.76,
     "SQMI": 477.71,
-    "centroid_lon": -107.1955276,
-    "centroid_lat": 39.20693567
+    "lng": -107.1955276,
+    "lat": 39.20693567
   },
   "81624": {
     "PO_NAME": "Collbran",
@@ -4433,8 +4433,8 @@
     "POPULATION": 1802,
     "POP_SQMI": 3.16,
     "SQMI": 570.42,
-    "centroid_lon": -107.7836947,
-    "centroid_lat": 39.24465945
+    "lng": -107.7836947,
+    "lat": 39.24465945
   },
   "81625": {
     "PO_NAME": "Craig",
@@ -4442,8 +4442,8 @@
     "POPULATION": 13230,
     "POP_SQMI": 8.69,
     "SQMI": 1522.35,
-    "centroid_lon": -107.7677954,
-    "centroid_lat": 40.64811059
+    "lng": -107.7677954,
+    "lat": 40.64811059
   },
   "81630": {
     "PO_NAME": "De Beque",
@@ -4451,8 +4451,8 @@
     "POPULATION": 1174,
     "POP_SQMI": 0.95,
     "SQMI": 1234.88,
-    "centroid_lon": -108.5500633,
-    "centroid_lat": 39.45273814
+    "lng": -108.5500633,
+    "lat": 39.45273814
   },
   "81631": {
     "PO_NAME": "Eagle",
@@ -4460,8 +4460,8 @@
     "POPULATION": 8658,
     "POP_SQMI": 35.58,
     "SQMI": 243.32,
-    "centroid_lon": -106.7113576,
-    "centroid_lat": 39.54939481
+    "lng": -106.7113576,
+    "lat": 39.54939481
   },
   "81632": {
     "PO_NAME": "Edwards",
@@ -4469,8 +4469,8 @@
     "POPULATION": 12433,
     "POP_SQMI": 349.73,
     "SQMI": 35.55,
-    "centroid_lon": -106.6333861,
-    "centroid_lat": 39.62634351
+    "lng": -106.6333861,
+    "lat": 39.62634351
   },
   "81633": {
     "PO_NAME": "Dinosaur",
@@ -4478,8 +4478,8 @@
     "POPULATION": 52,
     "POP_SQMI": 0.16,
     "SQMI": 330.14,
-    "centroid_lon": -108.3615386,
-    "centroid_lat": 40.31879832
+    "lng": -108.3615386,
+    "lat": 40.31879832
   },
   "81635": {
     "PO_NAME": "Parachute",
@@ -4487,8 +4487,8 @@
     "POPULATION": 6708,
     "POP_SQMI": 18.73,
     "SQMI": 358.15,
-    "centroid_lon": -108.0754016,
-    "centroid_lat": 39.54653659
+    "lng": -108.0754016,
+    "lat": 39.54653659
   },
   "81637": {
     "PO_NAME": "Gypsum",
@@ -4496,8 +4496,8 @@
     "POPULATION": 9158,
     "POP_SQMI": 12.46,
     "SQMI": 735.21,
-    "centroid_lon": -107.0733205,
-    "centroid_lat": 39.79064155
+    "lng": -107.0733205,
+    "lat": 39.79064155
   },
   "81638": {
     "PO_NAME": "Hamilton",
@@ -4505,8 +4505,8 @@
     "POPULATION": 183,
     "POP_SQMI": 0.68,
     "SQMI": 268.33,
-    "centroid_lon": -107.6062997,
-    "centroid_lat": 40.32057755
+    "lng": -107.6062997,
+    "lat": 40.32057755
   },
   "81639": {
     "PO_NAME": "Hayden",
@@ -4514,8 +4514,8 @@
     "POPULATION": 2573,
     "POP_SQMI": 3.02,
     "SQMI": 851.5,
-    "centroid_lon": -107.1977805,
-    "centroid_lat": 40.63983081
+    "lng": -107.1977805,
+    "lat": 40.63983081
   },
   "81640": {
     "PO_NAME": "Maybell",
@@ -4523,8 +4523,8 @@
     "POPULATION": 305,
     "POP_SQMI": 0.15,
     "SQMI": 1981.63,
-    "centroid_lon": -108.5208418,
-    "centroid_lat": 40.71830916
+    "lng": -108.5208418,
+    "lat": 40.71830916
   },
   "81641": {
     "PO_NAME": "Meeker",
@@ -4532,8 +4532,8 @@
     "POPULATION": 3992,
     "POP_SQMI": 2.9,
     "SQMI": 1378.43,
-    "centroid_lon": -107.7086045,
-    "centroid_lat": 40.05457578
+    "lng": -107.7086045,
+    "lat": 40.05457578
   },
   "81642": {
     "PO_NAME": "Meredith",
@@ -4541,8 +4541,8 @@
     "POPULATION": 249,
     "POP_SQMI": 3.35,
     "SQMI": 74.43,
-    "centroid_lon": -106.5716078,
-    "centroid_lat": 39.32432016
+    "lng": -106.5716078,
+    "lat": 39.32432016
   },
   "81643": {
     "PO_NAME": "Mesa",
@@ -4550,8 +4550,8 @@
     "POPULATION": 1001,
     "POP_SQMI": 3.69,
     "SQMI": 271.21,
-    "centroid_lon": -108.1232213,
-    "centroid_lat": 39.07382488
+    "lng": -108.1232213,
+    "lat": 39.07382488
   },
   "81645": {
     "PO_NAME": "Minturn",
@@ -4559,8 +4559,8 @@
     "POPULATION": 1538,
     "POP_SQMI": 141.88,
     "SQMI": 10.84,
-    "centroid_lon": -106.3955835,
-    "centroid_lat": 39.54967016
+    "lng": -106.3955835,
+    "lat": 39.54967016
   },
   "81647": {
     "PO_NAME": "New Castle",
@@ -4568,8 +4568,8 @@
     "POPULATION": 7907,
     "POP_SQMI": 21.26,
     "SQMI": 371.91,
-    "centroid_lon": -107.5244631,
-    "centroid_lat": 39.6069405
+    "lng": -107.5244631,
+    "lat": 39.6069405
   },
   "81648": {
     "PO_NAME": "Rangely",
@@ -4577,8 +4577,8 @@
     "POPULATION": 2974,
     "POP_SQMI": 2.48,
     "SQMI": 1198.46,
-    "centroid_lon": -108.7453643,
-    "centroid_lat": 39.96657249
+    "lng": -108.7453643,
+    "lat": 39.96657249
   },
   "81649": {
     "PO_NAME": "Red Cliff",
@@ -4586,8 +4586,8 @@
     "POPULATION": 372,
     "POP_SQMI": 1690.91,
     "SQMI": 0.22,
-    "centroid_lon": -106.3697945,
-    "centroid_lat": 39.51048555
+    "lng": -106.3697945,
+    "lat": 39.51048555
   },
   "81650": {
     "PO_NAME": "Rifle",
@@ -4595,8 +4595,8 @@
     "POPULATION": 13936,
     "POP_SQMI": 13.15,
     "SQMI": 1059.54,
-    "centroid_lon": -108.1158227,
-    "centroid_lat": 39.76526661
+    "lng": -108.1158227,
+    "lat": 39.76526661
   },
   "81652": {
     "PO_NAME": "Silt",
@@ -4604,8 +4604,8 @@
     "POPULATION": 5563,
     "POP_SQMI": 53.5,
     "SQMI": 103.99,
-    "centroid_lon": -107.6759491,
-    "centroid_lat": 39.46439235
+    "lng": -107.6759491,
+    "lat": 39.46439235
   },
   "81653": {
     "PO_NAME": "Slater",
@@ -4613,8 +4613,8 @@
     "POPULATION": 25,
     "POP_SQMI": 0.14,
     "SQMI": 180.57,
-    "centroid_lon": -107.4510164,
-    "centroid_lat": 40.91602646
+    "lng": -107.4510164,
+    "lat": 40.91602646
   },
   "81654": {
     "PO_NAME": "Snowmass",
@@ -4622,8 +4622,8 @@
     "POPULATION": 1472,
     "POP_SQMI": 13.97,
     "SQMI": 105.36,
-    "centroid_lon": -107.0249468,
-    "centroid_lat": 39.21796512
+    "lng": -107.0249468,
+    "lat": 39.21796512
   },
   "81655": {
     "PO_NAME": "Wolcott",
@@ -4631,8 +4631,8 @@
     "POPULATION": 299,
     "POP_SQMI": 15.16,
     "SQMI": 19.72,
-    "centroid_lon": -106.6949937,
-    "centroid_lat": 39.69274516
+    "lng": -106.6949937,
+    "lat": 39.69274516
   },
   "81656": {
     "PO_NAME": "Woody Creek",
@@ -4640,8 +4640,8 @@
     "POPULATION": 369,
     "POP_SQMI": 205,
     "SQMI": 1.8,
-    "centroid_lon": -106.8899165,
-    "centroid_lat": 39.28224719
+    "lng": -106.8899165,
+    "lat": 39.28224719
   },
   "81657": {
     "PO_NAME": "Vail",
@@ -4649,8 +4649,8 @@
     "POPULATION": 5977,
     "POP_SQMI": 13.65,
     "SQMI": 437.93,
-    "centroid_lon": -106.3939827,
-    "centroid_lat": 39.55226248
+    "lng": -106.3939827,
+    "lat": 39.55226248
   },
   "00027": {
     "PO_NAME": "Pike Ntl Forest",
@@ -4658,7 +4658,358 @@
     "POPULATION": null,
     "POP_SQMI": null,
     "SQMI": 43.02,
-    "centroid_lon": -104.98532,
-    "centroid_lat": 38.87175006
+    "lng": -104.98532,
+    "lat": 38.87175006
+  },
+  "80165": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -105.01,
+    "lat": 39.62
+  },
+  "80166": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -105.02,
+    "lat": 39.61
+  },
+  "80208": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.96,
+    "lat": 39.68
+  },
+  "80243": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.941094,
+    "lat": 39.71705351
+  },
+  "80244": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": 104.9800379,
+    "lat": 39.73995275
+  },
+  "80251": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9800678,
+    "lat": 39.74003534
+  },
+  "80256": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9799143,
+    "lat": 39.74032813
+  },
+  "80257": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9908362,
+    "lat": 39.74896607
+  },
+  "80259": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.980086,
+    "lat": 39.73980014
+  },
+  "80261": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9799143,
+    "lat": 39.74026213
+  },
+  "80262": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9664018,
+    "lat": 39.71636862
+  },
+  "80263": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9102576,
+    "lat": 39.64986596
+  },
+  "80266": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9006783,
+    "lat": 39.79017061
+  },
+  "80271": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9884181,
+    "lat": 39.71747928
+  },
+  "80273": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.980086,
+    "lat": 39.74006413
+  },
+  "80274": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9873349,
+    "lat": 39.74414735
+  },
+  "80281": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9798285,
+    "lat": 39.74026213
+  },
+  "80291": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.9802576,
+    "lat": 39.73960214
+  },
+  "80314": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -105.2699143,
+    "lat": 40.01999818
+  },
+  "80551": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.88227,
+    "lat": 40.46026471
+  },
+  "80553": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -105.0501385,
+    "lat": 40.56999256
+  },
+  "80638": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.7100859,
+    "lat": 40.4203249
+  },
+  "80826": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -103.6957221,
+    "lat": 39.21599677
+  },
+  "80941": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.806938,
+    "lat": 38.93292183
+  },
+  "80942": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.8247904,
+    "lat": 38.83391332
+  },
+  "80945": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.7942081,
+    "lat": 38.83652373
+  },
+  "80946": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.82,
+    "lat": 38.85
+  },
+  "80947": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.82,
+    "lat": 38.83
+  },
+  "80950": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.8,
+    "lat": 38.84
+  },
+  "80977": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.66,
+    "lat": 38.77
+  },
+  "80995": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.79,
+    "lat": 38.96
+  },
+  "80997": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.75,
+    "lat": 38.9
+  },
+  "81009": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.5,
+    "lat": 38.28
+  },
+  "81010": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.61,
+    "lat": 38.27
+  },
+  "81011": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.61,
+    "lat": 38.27
+  },
+  "81012": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -104.61,
+    "lat": 38.27
+  },
+  "81034": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -103.79,
+    "lat": 38.35
+  },
+  "81075": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -102.18,
+    "lat": 37.29
+  },
+  "81290": {
+    "PO_NAME": "",
+    "STATE": "CO",
+    "POPULATION": null,
+    "POP_SQMI": null,
+    "SQMI": null,
+    "lng": -105.12,
+    "lat": 38.38
   }
 }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -30,9 +30,9 @@ export interface ZipData {
     STATE: string;
     POPULATION: number | null;
     POP_SQMI: number | null;
-    SQMI: number;
-    centroid_lon: number;
-    centroid_lat: number;
+    SQMI: number | null;
+    lng: number;
+    lat: number;
   };
 }
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -58,7 +58,7 @@ export const getZipSearchMetadata = (zip: string): ZipSearchMetadata => {
   return {
     isValidZip: true,
     defaultRadiusMiles,
-    center: { lat: data.centroid_lat, lng: data.centroid_lon },
+    center: { lat: data.lat, lng: data.lng },
   };
 };
 


### PR DESCRIPTION
## Changes
adding latlong data for edge-case-y zips. also updated naming since not all our data is centroids anymore.

note that some of the searches are kinda awkward b/c they are in dense areas and return a bunch of results b/c we don't have pop density data (we default to 10 mi radius unless we have high pop density, in which case we default to 5mi), but i figure it's not worth handling for edge cases, since getting population data is prob gonna be even higher lift than getting the centers

## Screenshots
a previously missing zip
<img width="355" alt="Screen Shot 2022-09-15 at 11 35 49 AM" src="https://user-images.githubusercontent.com/1406537/190483215-202d3ff2-d183-4206-b2fc-637823b76780.png">

## Checklist
- [ ] if adds a new page, adds accessibility tests
- [ ] if adds a new page or new interaction, adds e2e test
- [ ] if adds a new page or new interaction, sends google analytics events and updates [GA doc](https://docs.google.com/document/d/1DfQDUNZPO3B352EhUwXp0el6qrAWz8Jq9cTa1yv8Ty4/edit)
- [ ] if changes filter functionality, updates [filters doc](https://docs.google.com/document/d/1yEdo7IpHCtEKNNF6FMLapBUgcPw_8CY7wGwxKTdtJrU/edit)

Fixes https://app.asana.com/0/1202690670605811/1202867132407675/f
