### PR TITLE
add private insurance note to provider detail page

### DIFF
--- a/src/components/ResultDetail/BasicResultDetail.tsx
+++ b/src/components/ResultDetail/BasicResultDetail.tsx
@@ -17,25 +17,19 @@ import { Fragment } from "react";
 import FeesInfo from "./FeesInfo";
 
 type BasicResultDetailProps = {
-  headingLevel: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   result: CareProvider;
   isCondensed?: boolean;
 };
 
-function BasicResultDetail({
-  headingLevel,
-  result,
-  isCondensed,
-}: BasicResultDetailProps) {
+function BasicResultDetail({ result, isCondensed }: BasicResultDetailProps) {
   const { t } = useTranslation();
-  const Heading = headingLevel;
 
   return (
     <>
       <div className="margin-bottom-3">
         {result.phone && (
           <ResultDatum Icon={Telephone} key="telephone">
-            <Heading className="usa-sr-only">{t("telephoneNumber")}</Heading>
+            <h3 className="usa-sr-only">{t("telephoneNumber")}</h3>
             <Link variant="external" href={`tel:${result.phone}`}>
               {result.phone}
             </Link>
@@ -43,7 +37,7 @@ function BasicResultDetail({
         )}
         {!!result.address?.length && (
           <ResultDatum Icon={Location} key="address">
-            <Heading className="usa-sr-only">{t("address")}</Heading>
+            <h3 className="usa-sr-only">{t("address")}</h3>
             <div>
               {result.address.map((addr, idx) => (
                 <Fragment key={idx}>
@@ -56,16 +50,16 @@ function BasicResultDetail({
         )}
         {result.website && (
           <ResultDatum Icon={Website} key="website">
-            <Heading className="usa-sr-only">{t("website")}</Heading>
+            <h3 className="usa-sr-only">{t("website")}</h3>
             <WebsiteLink url={result.website} />
           </ResultDatum>
         )}
       </div>
 
       <ResultDatum Icon={DollarSign} key="fees">
-        <Heading className="font-body-sm margin-top-0 margin-bottom-05">
+        <h3 className="font-body-sm margin-top-0 margin-bottom-05">
           {t("feesTitle")}
-        </Heading>
+        </h3>
         {!!anyAreTrue(result.fees) ? (
           <>
             <FeesInfo fees={result.fees} isCondensed={isCondensed} />
@@ -79,9 +73,9 @@ function BasicResultDetail({
       </ResultDatum>
 
       <ResultDatum Icon={Clock} key="hours">
-        <Heading className="font-body-sm margin-top-0 margin-bottom-05">
+        <h3 className="font-body-sm margin-top-0 margin-bottom-05">
           {t("hours")}
-        </Heading>
+        </h3>
         <Hours hours={result.hours} />
       </ResultDatum>
     </>

--- a/src/components/ResultDetail/BasicResultDetail.tsx
+++ b/src/components/ResultDetail/BasicResultDetail.tsx
@@ -12,16 +12,21 @@ import Hours from "./Hours";
 
 import { CareProvider } from "../../types";
 import { anyAreTrue } from "../../utils";
-import CommaSeparatedList from "../CommaSeparatedList";
 import WebsiteLink from "./WebsiteLink";
 import { Fragment } from "react";
+import FeesInfo from "./FeesInfo";
 
 type BasicResultDetailProps = {
   headingLevel: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   result: CareProvider;
+  isCondensed?: boolean;
 };
 
-function BasicResultDetail({ headingLevel, result }: BasicResultDetailProps) {
+function BasicResultDetail({
+  headingLevel,
+  result,
+  isCondensed,
+}: BasicResultDetailProps) {
   const { t } = useTranslation();
   const Heading = headingLevel;
 
@@ -63,10 +68,7 @@ function BasicResultDetail({ headingLevel, result }: BasicResultDetailProps) {
         </Heading>
         {!!anyAreTrue(result.fees) ? (
           <>
-            <CommaSeparatedList
-              boolMap={result.fees}
-              translationPrefix="feesValues"
-            />
+            <FeesInfo fees={result.fees} isCondensed={isCondensed} />
             {/* <Button type="button" unstyled className="font-ui-xs">
                 What do these mean?
               </Button> */}

--- a/src/components/ResultDetail/FeesInfo.tsx
+++ b/src/components/ResultDetail/FeesInfo.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { FeePreference } from "../../types";
+
+function FeesInfo({
+  fees,
+  isCondensed,
+}: {
+  fees: { [key in FeePreference]: boolean };
+  isCondensed?: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {Object.entries(fees)
+        .filter(([_, val]) => !!val)
+        .map(([key], idx, arr) => (
+          <React.Fragment key={key}>
+            {t(`feesValues${key}`)}
+            {!isCondensed && key === "PrivateInsurance" && "*"}
+            {idx < arr.length - 1 ? ", " : ""}
+          </React.Fragment>
+        ))}
+      {!isCondensed && fees.PrivateInsurance && (
+        <div className="margin-top-05">*{t(`privateInsuranceNote`)}</div>
+      )}
+    </>
+  );
+}
+
+export default FeesInfo;

--- a/src/components/ResultDetail/FeesInfo.tsx
+++ b/src/components/ResultDetail/FeesInfo.tsx
@@ -23,7 +23,9 @@ function FeesInfo({
           </React.Fragment>
         ))}
       {!isCondensed && fees.PrivateInsurance && (
-        <div className="margin-top-05">*{t(`privateInsuranceNote`)}</div>
+        <div className="margin-top-05 font-body-3xs">
+          *{t(`privateInsuranceNote`)}
+        </div>
       )}
     </>
   );

--- a/src/components/Search/ResultCard.tsx
+++ b/src/components/Search/ResultCard.tsx
@@ -21,7 +21,7 @@ export default function ResultCard({ data }: ResultCardProps) {
         <MilesAway meters={data.distance} />
       </div>
       <h2 className="margin-top-1 margin-bottom-3">{data.name}</h2>
-      <BasicResultDetail headingLevel="h3" result={data} isCondensed />
+      <BasicResultDetail result={data} isCondensed />
       <Link
         className="usa-button"
         to={`/result/${data.id}`}

--- a/src/components/Search/ResultCard.tsx
+++ b/src/components/Search/ResultCard.tsx
@@ -21,7 +21,7 @@ export default function ResultCard({ data }: ResultCardProps) {
         <MilesAway meters={data.distance} />
       </div>
       <h2 className="margin-top-1 margin-bottom-3">{data.name}</h2>
-      <BasicResultDetail headingLevel="h3" result={data} />
+      <BasicResultDetail headingLevel="h3" result={data} isCondensed />
       <Link
         className="usa-button"
         to={`/result/${data.id}`}

--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,9 @@ legend,
 [class*="font-body-"] {
   font-family: Trebuchet MS, san-serif !important;
 }
+.font-body-3xs {
+  font-size: 0.75rem;
+}
 
 .usa-button,
 .usa-card__container,

--- a/src/pages/ResultDetail.tsx
+++ b/src/pages/ResultDetail.tsx
@@ -93,7 +93,7 @@ function ResultDetail() {
             )}
           </Grid>
           <Grid tablet={{ col: 5 }}>
-            <BasicResultDetail headingLevel="h3" result={data} />
+            <BasicResultDetail result={data} />
           </Grid>
         </Grid>
       </section>


### PR DESCRIPTION
## Changes
adding a prop so that we can display diff versions of provider deets on search listing (condensed) vs detail page (verbose), and include a note when providers support private insurance

## Screenshots
<img width="419" alt="Screen Shot 2022-09-15 at 4 41 39 PM" src="https://user-images.githubusercontent.com/1406537/190527340-60ef40d7-61ea-451a-9bef-90b3965eb42f.png">

## Checklist

- [ ] if adds a new page, adds accessibility tests
- [ ] if adds a new page or new interaction, adds e2e test
- [ ] if adds a new page or new interaction, sends google analytics events and updates [GA doc](https://docs.google.com/document/d/1DfQDUNZPO3B352EhUwXp0el6qrAWz8Jq9cTa1yv8Ty4/edit)
- [ ] if changes filter functionality, updates [filters doc](https://docs.google.com/document/d/1yEdo7IpHCtEKNNF6FMLapBUgcPw_8CY7wGwxKTdtJrU/edit)

Fixes https://app.asana.com/0/1202105544020589/1202709753443460/f