### PR TITLE
bigger external link icon

### DIFF
--- a/src/images/launch.svg
+++ b/src/images/launch.svg
@@ -1,0 +1,5 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.33337 6.55518V9.88843C9.33337 10.1827 9.21619 10.4655 9.00786 10.6739C8.79953 10.8822 8.51673 10.9994 8.22243 10.9994H2.11092C1.49738 10.9994 1 10.502 1 9.88845V3.77693C1 3.16339 1.49738 2.66602 2.11092 2.66602H5.44417" stroke="#2F6FA7" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.66638 1H10.9996V4.33325" stroke="#2F6FA7" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.88892 7.11096L10.9999 1" stroke="#2F6FA7" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -105,6 +105,9 @@ legend,
   color: #2f6fa7;
   text-decoration: none;
 }
+.usa-link--external::after {
+  background-size: 120%;
+}
 
 .dark-background,
 .usa-link.dark-background {

--- a/src/index.css
+++ b/src/index.css
@@ -105,8 +105,9 @@ legend,
   color: #2f6fa7;
   text-decoration: none;
 }
-.usa-link--external::after {
-  background-size: 120%;
+.usa-link--external::after,
+.usa-link--external:hover::after {
+  background-image: url(./images/launch.svg);
 }
 
 .dark-background,


### PR DESCRIPTION
## Changes
increasing the size of icon after external links

@admoorgit i couldn't make the icon match the color of the link in a clean/simple way. i was able to do it in a pretty hacky way, but it felt like the benefit wasn't worth the messy hackery - lmk if you think the color matching is important tho

## Screenshots
<img width="255" alt="Screen Shot 2022-09-16 at 10 26 12 AM" src="https://user-images.githubusercontent.com/1406537/190696765-478807b7-309e-455f-8591-24a6e00396f6.png">

## Checklist

- [ ] if adds a new page, adds accessibility tests
- [ ] if adds a new page or new interaction, adds e2e test
- [ ] if adds a new page or new interaction, sends google analytics events and updates [GA doc](https://docs.google.com/document/d/1DfQDUNZPO3B352EhUwXp0el6qrAWz8Jq9cTa1yv8Ty4/edit)
- [ ] if changes filter functionality, updates [filters doc](https://docs.google.com/document/d/1yEdo7IpHCtEKNNF6FMLapBUgcPw_8CY7wGwxKTdtJrU/edit)

Fixes https://app.asana.com/0/1202690670605811/1202791688500275/f
