### PR TITLE
Accessibility fixes provider names links

### DIFF
--- a/src/components/Search/ResultCard.tsx
+++ b/src/components/Search/ResultCard.tsx
@@ -20,7 +20,13 @@ export default function ResultCard({ data }: ResultCardProps) {
         </p>
         <MilesAway meters={data.distance} />
       </div>
-      <h2 className="margin-top-1 margin-bottom-3">{data.name}</h2>
+      <Link
+        className="usa-link"
+        to={`/result/${data.id}`}
+        state={{ prevSearch: location.search, data }}
+      >
+        <h2 className="margin-top-1 margin-bottom-3">{data.name}</h2>
+      </Link>
       <BasicResultDetail result={data} isCondensed />
       <Link
         className="usa-button"


### PR DESCRIPTION
## Changes

Makes provider names into clickable links in search results. On my browser, they don't display as highlighted with the active selection box (i think due to nesting the h2 inside the link, but for semantic and style reasons i chose this over a > h2; open to discussion tho). However, they are indeed the active element (as indicated by the link displayed at the bottom and you can navigate to them by hitting enter)

## Screenshots
![provider_name_results_link](https://user-images.githubusercontent.com/54035880/198383576-35ed5821-d290-4657-9b3a-02cd019de037.gif)

Fixes https://app.asana.com/0/0/1203228691996329/f
