### PR TITLE
make compare page zip-aware

### DIFF
--- a/src/components/Compare/CompareDetail.tsx
+++ b/src/components/Compare/CompareDetail.tsx
@@ -5,11 +5,19 @@ import { useTranslation } from "react-i18next";
 
 import { CareProvider } from "../../types";
 import DirectionsLink from "../ResultDetail/DirectionsLink";
+import { getMilesToZipCenter } from "../../utils";
 
 // TODO: add badges for telehealth and accepting new patients when we have them
 
-function CompareDetail({ data }: { data: CareProvider }) {
+function CompareDetail({
+  data,
+  zip,
+}: {
+  data: CareProvider;
+  zip: string | null;
+}) {
   const { t } = useTranslation();
+  const miles = getMilesToZipCenter(zip, data);
 
   return (
     <>
@@ -40,6 +48,11 @@ function CompareDetail({ data }: { data: CareProvider }) {
             </>
           )}
         </div>
+        {miles !== null && (
+          <div className="margin-bottom-1">
+            {t("milesAwayFrom", { miles: miles.toFixed(1), zip })}
+          </div>
+        )}
         <DirectionsLink careProvider={data} />
       </div>
     </>

--- a/src/components/Search/MilesAway.tsx
+++ b/src/components/Search/MilesAway.tsx
@@ -1,9 +1,9 @@
 import { useTranslation } from "react-i18next";
-import { METERS_IN_A_MILE } from "../../utils";
+import { getMilesFromMeters } from "../../utils";
 
 export default function MilesAway({ meters }: { meters?: number }) {
   const { t } = useTranslation();
-  const miles = meters ? (meters / METERS_IN_A_MILE).toFixed(1) : "??";
+  const miles = meters ? getMilesFromMeters(meters).toFixed(1) : "??";
   return (
     <p className="margin-top-0 margin-bottom-0 text-bold">
       {t("milesAway", { miles })}

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -39,6 +39,7 @@ export default function Compare() {
   };
 
   const ids = params.getAll("id");
+  const zip = params.get("zip");
 
   if (!ids || ids.length !== 2) {
     return <Navigate replace to="/" />;
@@ -95,11 +96,11 @@ export default function Compare() {
         <Grid row gap="md">
           <Grid col={6}>
             <p className="margin-y-2 text-bold">1.</p>
-            <CompareDetail data={providerA} />
+            <CompareDetail data={providerA} zip={zip} />
           </Grid>
           <Grid col={6}>
             <p className="margin-y-2 text-bold">2.</p>
-            <CompareDetail data={providerB} />
+            <CompareDetail data={providerB} zip={zip} />
           </Grid>
         </Grid>
       </GridContainer>

--- a/src/translations/en_translations.json
+++ b/src/translations/en_translations.json
@@ -78,6 +78,7 @@
   "mapHelper": "Tap a marker to pull up information for that location. To zoom in or out on the map on a mobile device, use a two finger pinching gesture.",
   "fullDetail": "Full detail about this location",
   "milesAway": "{{ miles }} miles away",
+  "milesAwayFrom": "{{ miles }} miles away from {{zip}}",
   "detailsPageShare": "Share link",
   "backToSearch": "Back to search",
   "getDirections": "Get directions",

--- a/src/utils/filters/distance.ts
+++ b/src/utils/filters/distance.ts
@@ -40,3 +40,7 @@ export const compareDistance = (
   }
   return a.distance - b.distance;
 };
+
+export const getMilesFromMeters = (meters: number): number => {
+  return meters / METERS_IN_A_MILE;
+};

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -23,8 +23,26 @@ import {
   offersAnyTypesOfHelpNeeded,
   servesAgeGroup,
   getDefaultRadius,
+  getMilesFromMeters,
 } from "./filters";
 import { supportsLanguages } from "./filters/languages";
+
+export const getMilesToZipCenter = (
+  zip: string | null,
+  careProvider: CareProvider
+): number | null => {
+  if (!zip) {
+    return null;
+  }
+  const zipSearchMetadata = getZipSearchMetadata(zip);
+  if (!zipSearchMetadata.isValidZip || !careProvider.latlng) {
+    return null;
+  }
+  const meters = latLng(zipSearchMetadata.center).distanceTo(
+    careProvider.latlng
+  );
+  return getMilesFromMeters(meters);
+};
 
 export const addSearchMetadata = (
   careProviders: CareProvider[],


### PR DESCRIPTION
## Changes
adding zip param to compare page so that we can keep zip context from the search, and display distance to zip in location compare deets

## Screenshots
<img width="569" alt="Screen Shot 2022-11-01 at 5 38 46 AM" src="https://user-images.githubusercontent.com/1406537/199234232-7852a2aa-64d1-4f73-9c12-d2e3a7ff360e.png">


## Checklist

- [ ] if adds a new page, adds accessibility tests
- [ ] if adds a new page or new interaction, adds e2e test
- [ ] if adds a new page or new interaction, sends google analytics events and updates [GA doc](https://docs.google.com/document/d/1DfQDUNZPO3B352EhUwXp0el6qrAWz8Jq9cTa1yv8Ty4/edit)
- [ ] if changes filter functionality, updates [filters doc](https://docs.google.com/document/d/1yEdo7IpHCtEKNNF6FMLapBUgcPw_8CY7wGwxKTdtJrU/edit)

Fixes https://app.asana.com/0/0/1203261751786616/f
