### PR TITLE
Wire in accepting new patients and telehealth badge

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -22,12 +22,6 @@ const StyledBadge = styled(Tag)`
     }
 `;
 
-const StyledWrapperDiv = styled.div`
-    + .usa-tooltip__body {
-        font-family: "Source Sans Pro Web";
-    }
-`;
-
 type ConditionalBadgeProps =
     | {
         showTooltip?: false;
@@ -56,9 +50,9 @@ const WrapperDivForwardRef: React.ForwardRefRenderFunction<
     HTMLDivElement,
     WrapperDivProps
 > = ({ className, children, ...tooltipProps }: WrapperDivProps, ref) => (
-    <StyledWrapperDiv ref={ref} className={className} {...tooltipProps}>
+    <div ref={ref} className={className} {...tooltipProps}>
         {children}
-    </StyledWrapperDiv>
+    </div>
 );
 const WrapperDiv = React.forwardRef(WrapperDivForwardRef);
 

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,4 +1,5 @@
-import { Tag } from "@trussworks/react-uswds";
+import React from "react";
+import { Tag, Tooltip } from "@trussworks/react-uswds";
 import styled from "styled-components";
 
 const StyledBadge = styled(Tag)`
@@ -21,16 +22,67 @@ const StyledBadge = styled(Tag)`
     }
 `;
 
-type BadgeProps = {
+const StyledWrapperDiv = styled.div`
+    + .usa-tooltip__body {
+        font-family: "Source Sans Pro Web";
+    }
+`;
+
+type ConditionalBadgeProps =
+    | {
+        showTooltip?: false;
+        tooltipText?: never;
+    }
+    | {
+        showTooltip?: true;
+        tooltipText: string;
+    };
+
+type CommonBadgeProps = {
     bgColor: 'blue' | 'yellow';
     Icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
     text: string;
 };
 
-export default function Badge({ Icon, bgColor, text }: BadgeProps) {
-    return (
-        <StyledBadge background={`var(--badge-bg-${bgColor})`}>
-            <span className="badge-icon"><Icon /></span>{' '}<span className="badge-text">{text}</span>
+type BadgeProps = CommonBadgeProps & ConditionalBadgeProps;
+
+// ForwardRef of wrapper div around Tag component
+type WrapperDivProps = React.PropsWithChildren<{
+    className?: string;
+}> &
+    JSX.IntrinsicElements['div'] &
+    React.RefAttributes<HTMLDivElement>;
+const WrapperDivForwardRef: React.ForwardRefRenderFunction<
+    HTMLDivElement,
+    WrapperDivProps
+> = ({ className, children, ...tooltipProps }: WrapperDivProps, ref) => (
+    <StyledWrapperDiv ref={ref} className={className} {...tooltipProps}>
+        {children}
+    </StyledWrapperDiv>
+);
+const WrapperDiv = React.forwardRef(WrapperDivForwardRef);
+
+export default function Badge({ Icon, bgColor, text, tooltipText, showTooltip = false }: BadgeProps) {
+    const renderBadge = () => (
+        <StyledBadge
+            background={`var(--badge-bg-${bgColor})`}>
+            <span className="badge-icon"><Icon /></span>{' '}<span className="badge-text">
+                {text}
+            </span>
         </StyledBadge>
+    );
+
+    return (
+        showTooltip ?
+            <Tooltip<WrapperDivProps>
+                label={tooltipText ?? ''}
+                position="top"
+                className="margin-right-1"
+                asCustom={WrapperDiv}>
+                {renderBadge()}
+            </Tooltip>
+            :
+            <>{renderBadge()}</>
+
     );
 }

--- a/src/components/ResultDetail/BasicResultDetail.tsx
+++ b/src/components/ResultDetail/BasicResultDetail.tsx
@@ -6,6 +6,7 @@ import { ReactComponent as Website } from "../../images/website.svg";
 import { ReactComponent as Location } from "../../images/location.svg";
 import { ReactComponent as DollarSign } from "../../images/dollar-sign.svg";
 import { ReactComponent as Clock } from "../../images/clock.svg";
+import { ReactComponent as BadgeCheck } from "../../images/badge-check.svg";
 import { ReactComponent as Telehealth } from "../../images/telehealth.svg";
 
 import ResultDatum from "./ResultDatum";
@@ -29,11 +30,20 @@ function BasicResultDetail({ result, isCondensed }: BasicResultDetailProps) {
   return (
     <>
       <div className="margin-bottom-3">
+        {result.acceptingNewPatients && (
+          <Badge
+            bgColor="blue"
+            Icon={BadgeCheck}
+            text={t("acceptingNewPatients")}
+            showTooltip
+            tooltipText={t("acceptingNewPatientsNote")}
+          />
+        )}
         {result.offersTelehealth && (
           <Badge
             bgColor="yellow"
             Icon={Telehealth}
-            text="Telehealth available"
+            text={t("telehealthAvailable")}
           />
         )}
       </div>

--- a/src/components/ResultDetail/BasicResultDetail.tsx
+++ b/src/components/ResultDetail/BasicResultDetail.tsx
@@ -6,9 +6,7 @@ import { ReactComponent as Website } from "../../images/website.svg";
 import { ReactComponent as Location } from "../../images/location.svg";
 import { ReactComponent as DollarSign } from "../../images/dollar-sign.svg";
 import { ReactComponent as Clock } from "../../images/clock.svg";
-// TODO: wire in badges to list
-// import { ReactComponent as BadgeCheck } from "../../images/badge-check.svg";
-// import { ReactComponent as Telehealth } from "../../images/telehealth.svg";
+import { ReactComponent as Telehealth } from "../../images/telehealth.svg";
 
 import ResultDatum from "./ResultDatum";
 import Hours from "./Hours";
@@ -18,8 +16,7 @@ import { anyAreTrue } from "../../utils";
 import WebsiteLink from "./WebsiteLink";
 import { Fragment } from "react";
 import FeesInfo from "./FeesInfo";
-// TODO: wire in badges to list
-// import Badge from "../Badge";
+import Badge from "../Badge";
 
 type BasicResultDetailProps = {
   result: CareProvider;
@@ -31,6 +28,15 @@ function BasicResultDetail({ result, isCondensed }: BasicResultDetailProps) {
 
   return (
     <>
+      <div className="margin-bottom-3">
+        {result.offersTelehealth && (
+          <Badge
+            bgColor="yellow"
+            Icon={Telehealth}
+            text="Telehealth available"
+          />
+        )}
+      </div>
       <div className="margin-bottom-3">
         {result.phone && (
           <ResultDatum Icon={Telephone} key="telephone">

--- a/src/data/process_data.ts
+++ b/src/data/process_data.ts
@@ -39,6 +39,7 @@ type InputRow = {
   HoursofOperationWednesday: string;
   LanguagesSpoken: string;
   MentalHealthSettings: string;
+  OffersTelehealth: string;
   OpioidTreatmentPrograms: string;
   Phone: string;
   PopulationServed: string;
@@ -162,6 +163,7 @@ const transformRow = (row: InputRow): CareProvider => {
     languages: getBooleanMap(LANGUAGES, splitBySemicolons(row.LanguagesSpoken)),
     latlng: getLatLng(row),
     lastUpdatedDate: row.ProviderDirectoryFormModifiedDate,
+    offersTelehealth: !!row.OffersTelehealth
   };
   return cleaned;
 };

--- a/src/data/process_data.ts
+++ b/src/data/process_data.ts
@@ -18,6 +18,7 @@ const INPUT_FILE = "../../raw_data/ladders.csv";
 const OUTPUT_FILE = "./ladders_data.json";
 
 type InputRow = {
+  AcceptingNewPatients: string;
   Accessibility: string;
   AccountID: string;
   AccountName: string;
@@ -123,6 +124,7 @@ const transformRow = (row: InputRow): CareProvider => {
     name: row.DisplayName,
     phone: row.Phone,
     hideAddress,
+    acceptingNewPatients: !!row.AcceptingNewPatients,
     address:
       hideAddress || !row.ProviderLocationDisplayLabel
         ? []

--- a/src/types/care_provider.ts
+++ b/src/types/care_provider.ts
@@ -2,10 +2,10 @@ import { LatLngLiteral } from "leaflet";
 
 export type DailyHours =
   | {
-      open: true;
-      start: string;
-      end: string;
-    }
+    open: true;
+    start: string;
+    end: string;
+  }
   | { open: false };
 
 export enum DayOfWeek {
@@ -38,6 +38,7 @@ export const SUBSTANCE_USE_SERVICES = [
   "MedicallyMonitoredInpatientDetoxification",
   "MedicallyMonitoredIntensiveResidentialTreatment",
   "MedicationAssistedTherapy",
+  "OffersTelehealth",
   "OpioidTreatmentPrograms",
   "Outpatient",
   "YouthTreatment",
@@ -54,6 +55,7 @@ export const MENTAL_HEALTH_SERVICES = [
   "Emergency",
   "Hospital",
   "IntensiveOutpatient",
+  "OffersTelehealth",
   "Outpatient",
   "PsychiatricResidential",
   "ResidentialChildCareFacility",
@@ -112,6 +114,12 @@ export const LANGUAGES = [
 ] as const;
 export type Languages = typeof LANGUAGES[number];
 
+export const TELEHEALTH_OPTIONS = [
+  "Telehealth Only",
+  "Telehealth Available - With Restrictions",
+] as const;
+export type TelehealthOptions = typeof TELEHEALTH_OPTIONS[number];
+
 export type CareProvider = {
   id: string;
   name: string;
@@ -136,4 +144,5 @@ export type CareProvider = {
   languages: { [key in Languages]: boolean };
   latlng: LatLngLiteral | null;
   lastUpdatedDate: string;
+  offersTelehealth: boolean;
 };

--- a/src/types/care_provider.ts
+++ b/src/types/care_provider.ts
@@ -38,7 +38,6 @@ export const SUBSTANCE_USE_SERVICES = [
   "MedicallyMonitoredInpatientDetoxification",
   "MedicallyMonitoredIntensiveResidentialTreatment",
   "MedicationAssistedTherapy",
-  "OffersTelehealth",
   "OpioidTreatmentPrograms",
   "Outpatient",
   "YouthTreatment",
@@ -55,7 +54,6 @@ export const MENTAL_HEALTH_SERVICES = [
   "Emergency",
   "Hospital",
   "IntensiveOutpatient",
-  "OffersTelehealth",
   "Outpatient",
   "PsychiatricResidential",
   "ResidentialChildCareFacility",
@@ -114,6 +112,11 @@ export const LANGUAGES = [
 ] as const;
 export type Languages = typeof LANGUAGES[number];
 
+export const ACCEPTING_NEW_PATIENTS_OPTIONS = [
+  "Yes"
+] as const;
+export type AcceptingNewPatientsOptions = typeof ACCEPTING_NEW_PATIENTS_OPTIONS[number];
+
 export const TELEHEALTH_OPTIONS = [
   "Telehealth Only",
   "Telehealth Available - With Restrictions",
@@ -125,6 +128,7 @@ export type CareProvider = {
   name: string;
   phone: string;
   hideAddress: boolean;
+  acceptingNewPatients: boolean;
   address: string[];
   addressStr: string;
   website: string;

--- a/src/utils.test.tsx
+++ b/src/utils.test.tsx
@@ -78,6 +78,7 @@ const DUMMY_CARE_PROVIDER: CareProvider = {
   }, {} as { [key in Languages]: boolean }),
   latlng: null,
   lastUpdatedDate: "7/7/2022 7:00 AM",
+  offersTelehealth: true
 };
 
 const DUMMY_CARE_PROVIDER_RESULT = { ...DUMMY_CARE_PROVIDER, searchRank: 1 };

--- a/src/utils.test.tsx
+++ b/src/utils.test.tsx
@@ -41,6 +41,7 @@ const DUMMY_CARE_PROVIDER: CareProvider = {
   name: "Care Provider",
   phone: "123-456-7890",
   hideAddress: false,
+  acceptingNewPatients: true,
   address: [],
   addressStr: "",
   website: "",


### PR DESCRIPTION
## Changes

- Add logic to include tooltip
- Add in telehealth badge to list and detail pages (will add 'accepting new patients' badge later and add to compare page when that item is finished)
- Add telehealth type into rows and transform object
- Add accepting new patients badge
- Add translations
- Add prop type
- Add prop to processed data

**Note: ToolTip is currently defaulting to right position due to length of text. Let me know if this is a blocker or not.**

![Screen Shot 2022-11-16 at 12 06 07 PM](https://user-images.githubusercontent.com/10701395/202286696-0ba4de00-35db-4f83-9f51-96bb16cef9dc.png)
![Screen Shot 2022-11-16 at 12 05 54 PM](https://user-images.githubusercontent.com/10701395/202286699-c99f1ca4-fd9e-4efb-9afe-519f44bf3f76.png)
![Screen Shot 2022-11-16 at 12 23 04 PM](https://user-images.githubusercontent.com/10701395/202286704-214521f0-8361-4f3e-8150-f59c61defa56.png)


## Checklist

- [ ] if adds a new page, adds accessibility tests
- [ ] if adds a new page or new interaction, adds e2e test
- [ ] if adds a new page or new interaction, sends google analytics events and updates [GA doc](https://docs.google.com/document/d/1DfQDUNZPO3B352EhUwXp0el6qrAWz8Jq9cTa1yv8Ty4/edit)
- [ ] if changes filter functionality, updates [filters doc](https://docs.google.com/document/d/1yEdo7IpHCtEKNNF6FMLapBUgcPw_8CY7wGwxKTdtJrU/edit)

https://app.asana.com/0/1203295759985135/1203326776555912
and
https://app.asana.com/0/1202690670605811/1202575963892263
