### PR TITLE
Add Banner with downtime/maintenance notification

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -22,14 +22,19 @@ const StyledDropdown = styled(Dropdown)`
 `;
 
 
+const MaintenanceBanner = styled.div`
+  background-color: #F8D347;
+`
+
 function Banner() {
   const { t, i18n } = useTranslation();
 
   return (
     <>
-    <div className="Banner bg-secondary-dark text-white font-body-xs padding-y-1 padding-x-3 desktop:padding-x-0 display-flex flex-align-center flex-justify-center">
-      <Info className="margin-right-1 display-none desktop:display-block" /> This site will be undergoing maintenance from approximately 11am to 2pm on April 27, 2023. If you see an error, please refresh the page.
-    </div>
+    <MaintenanceBanner className="Banner bg-secondary-dark text-black font-body-xs padding-y-1 padding-x-3 desktop:padding-x-0 display-flex flex-align-center flex-justify-center">
+      <Info className="margin-right-1 display-none desktop:display-block" /> 
+      OwnPath is getting better! Scheduled maintenance will be from 11am to 2pm today. If the page doesn't load, please refresh.
+    </MaintenanceBanner>
     <div className="Banner usa-dark-background font-body-3xs margin-bottom-1">
       <Grid row className="flex-justify-end">
         <Grid col="auto" className="padding-x-2">

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -3,6 +3,7 @@ import { Dropdown, Grid, Label } from "@trussworks/react-uswds";
 import { useTranslation } from "react-i18next";
 
 import { ReactComponent as Globe } from "../images/globe.svg";
+import { ReactComponent as Info} from "../images/info.svg";
 import caretDownURL from "../images/caret-down.svg";
 
 const StyledDropdown = styled(Dropdown)`
@@ -20,10 +21,15 @@ const StyledDropdown = styled(Dropdown)`
   background-size: 15%;
 `;
 
+
 function Banner() {
   const { t, i18n } = useTranslation();
 
   return (
+    <>
+    <div className="Banner bg-secondary-dark text-white font-body-xs padding-y-1 padding-x-3 desktop:padding-x-0 display-flex flex-align-center flex-justify-center">
+      <Info className="margin-right-1 display-none desktop:display-block" /> This site will be undergoing maintenance from approximately 11am to 2pm on April 27, 2023. If you see an error, please refresh the page.
+    </div>
     <div className="Banner usa-dark-background font-body-3xs margin-bottom-1">
       <Grid row className="flex-justify-end">
         <Grid col="auto" className="padding-x-2">
@@ -52,6 +58,7 @@ function Banner() {
         </Grid>
       </Grid>
     </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Changes

Adds temporary banner to site to alert users to potential issues during cut over. 

## Screenshots

desktop:
![image](https://user-images.githubusercontent.com/54035880/234857323-eaa31129-17e4-4cce-af1b-aeccdf13a99d.png)
mobile:
![image](https://user-images.githubusercontent.com/54035880/234858109-ba8b2fe9-a749-48c8-8743-0e10165368d4.png)

Fixes https://app.asana.com/0/1202105544020589/1204453721873222/f