### PR TITLE
Revert "Add Banner with downtime/maintenance notification (#427)"

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -3,7 +3,6 @@ import { Dropdown, Grid, Label } from "@trussworks/react-uswds";
 import { useTranslation } from "react-i18next";
 
 import { ReactComponent as Globe } from "../images/globe.svg";
-import { ReactComponent as Info} from "../images/info.svg";
 import caretDownURL from "../images/caret-down.svg";
 
 const StyledDropdown = styled(Dropdown)`
@@ -21,20 +20,10 @@ const StyledDropdown = styled(Dropdown)`
   background-size: 15%;
 `;
 
-
-const MaintenanceBanner = styled.div`
-  background-color: #F8D347;
-`
-
 function Banner() {
   const { t, i18n } = useTranslation();
 
   return (
-    <>
-    <MaintenanceBanner className="Banner bg-secondary-dark text-black font-body-xs padding-y-1 padding-x-3 desktop:padding-x-0 display-flex flex-align-center flex-justify-center">
-      <Info className="margin-right-1 display-none desktop:display-block" /> 
-      OwnPath is getting better! Scheduled maintenance will be from 11am to 2pm today. If the page doesn't load, please refresh.
-    </MaintenanceBanner>
     <div className="Banner usa-dark-background font-body-3xs margin-bottom-1">
       <Grid row className="flex-justify-end">
         <Grid col="auto" className="padding-x-2">
@@ -63,7 +52,6 @@ function Banner() {
         </Grid>
       </Grid>
     </div>
-    </>
   );
 }
 


### PR DESCRIPTION
Removes the banner for now, but can add back we attempt a production transition again.

## Checklist

- [ ] if changes filter/search functionality, adds or updates unit tests
- [ ] if adds a new page, adds accessibility tests
- [ ] if adds a new page or new interaction, adds e2e test
- [ ] if adds a new page or new interaction, sends google analytics events and updates [GA doc](https://docs.google.com/document/d/1DfQDUNZPO3B352EhUwXp0el6qrAWz8Jq9cTa1yv8Ty4/edit)
- [ ] if changes filter functionality, updates [filters doc](https://docs.google.com/document/d/1yEdo7IpHCtEKNNF6FMLapBUgcPw_8CY7wGwxKTdtJrU/edit)

Fixes [link to asana ticket here]
